### PR TITLE
Remove DevelopmentOnly binding

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/service/BackfilaServiceModule.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/BackfilaServiceModule.kt
@@ -29,8 +29,6 @@ class BackfilaServiceModule(
   override fun configure() {
     multibind<AccessAnnotationEntry>().toInstance(
         AccessAnnotationEntry<AdminDashboardAccess>(capabilities = listOf("backfila--owners")))
-    bind<MiskCaller>().annotatedWith<DevelopmentOnly>().toInstance(
-        MiskCaller(user = "development", capabilities = setOf("eng", "backfila--owners")))
 
     install(ConfigModule.create("backfila", config))
     install(EnvironmentModule(environment))


### PR DESCRIPTION
* Binding in BackfilaServiceModule is never used because BackfilaDevelopmentService is used instead in DEVELOPMENT environment