### PR TITLE
Backfila web UI: navbar color reflects environment

### DIFF
--- a/service/web/tabs/app/src/utilities/theme.ts
+++ b/service/web/tabs/app/src/utilities/theme.ts
@@ -14,10 +14,7 @@ const environmentColorLookup: IEnvironmentToColorLookup = {
   PRODUCTION: color.red
 }
 
-export const backfilaRed = "#db2636"
-
 export const backfilaTheme: ITheme = {
   ...defaultTheme,
-  environmentToColor: environmentToColor(environmentColorLookup),
-  navbarBackground: backfilaRed
+  environmentToColor: environmentToColor(environmentColorLookup)
 }


### PR DESCRIPTION
Fixes #16 

I noticed this using backfila. IMO, visual cues about the current environment can help reduce the risk of operational tasks, so this is pretty important.

That said, I kept the specific shade of red that we must've thought was nice when initially writing this.

Meta: The current README's instructions reference a nonexistent `BackfilaService.kt` _and_ there are some DI exceptions related to the web actions when trying to run `BackfilaDevelopmentService.kt`