### PR TITLE
Banish Log4J

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,12 @@ subprojects { subProject ->
     }
   }
 
+  // SLF4J uses the classpath to decide which logger to use! Banish the Log4J to prevent this:
+  // org.apache.logging.slf4j.Log4jLogger cannot be cast to class ch.qos.logback.classic.Logger
+  configurations.all {
+    exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
+  }
+
   // Workaround the Gradle bug resolving multiplatform dependencies.
   // https://github.com/square/okio/issues/647
   configurations.all { configuration ->


### PR DESCRIPTION
SLF4J scans the classpath and if it finds Log4J, it'll use it. Since Misk
wants Logback we need to banish its rivals.