### PR TITLE
Fix docs build by forcing Python 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,20 +92,10 @@ jobs:
     parallelism: 1
     steps:
       - checkout # check out source code to working directory
-      - run: |
-          sudo mkdir -p /usr/local/bin
-          sudo chown -R circleci:circleci /usr/local/bin
-      - run: |
-          sudo mkdir -p /usr/local/lib/python3.6/site-packages
-          sudo chown -R circleci:circleci /usr/local/lib/python3.6/site-packages
-      - restore_cache:
-          key: pipdeps-{{ .Branch }}
-      - run: sudo pip install mkdocs mkdocs-material
-      - save_cache:
-          key: pipdeps-{{ .Branch }}
-          paths:
-            - "/usr/local/bin"
-            - "/usr/local/lib/python3.6/site-packages"
+      - run: | # mkdocs wants to be run with Python 3, force the path to prioritize pyenv 3.5.2
+          pyenv global 3.5.2
+          export PATH="/opt/circleci/.pyenv/versions/3.5.2/lib/:$PATH"
+          pip install mkdocs mkdocs-material
       - run: |
           ./gradlew dokka
       - run: |


### PR DESCRIPTION
Following fix that worked in Misk: https://github.com/cashapp/misk/pull/1385