### PR TITLE
Add link to view logs

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/dashboard/BackfilaWebActionsModule.kt
+++ b/service/src/main/kotlin/app/cash/backfila/dashboard/BackfilaWebActionsModule.kt
@@ -14,5 +14,6 @@ class BackfilaWebActionsModule() : KAbstractModule() {
     install(WebActionModule.create<GetBackfillStatusAction>())
     install(WebActionModule.create<UpdateBackfillAction>())
     install(WebActionModule.create<RootRedirectAction>())
+    install(WebActionModule.create<ViewLogsAction>())
   }
 }

--- a/service/src/main/kotlin/app/cash/backfila/dashboard/ViewLogsAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/dashboard/ViewLogsAction.kt
@@ -1,0 +1,45 @@
+package app.cash.backfila.dashboard
+
+import app.cash.backfila.service.BackfilaDb
+import app.cash.backfila.service.DbBackfillRun
+import misk.exceptions.BadRequestException
+import misk.hibernate.Id
+import misk.hibernate.Session
+import misk.hibernate.Transacter
+import misk.hibernate.loadOrNull
+import misk.security.authz.Authenticated
+import misk.web.Get
+import misk.web.PathParam
+import misk.web.Response
+import misk.web.ResponseBody
+import misk.web.actions.WebAction
+import misk.web.toResponseBody
+import okhttp3.Headers
+import java.net.HttpURLConnection
+import javax.inject.Inject
+
+interface ViewLogsUrlProvider {
+  fun getUrl(session: Session, backfillRun: DbBackfillRun): String
+}
+
+class ViewLogsAction @Inject constructor(
+    @BackfilaDb private val transacter: Transacter,
+    private val viewLogsUrlProvider: ViewLogsUrlProvider
+) : WebAction {
+  @Get("/backfills/{id}/view-logs")
+  @Authenticated
+  fun viewLogs(
+      @PathParam id: Long
+  ): Response<ResponseBody> {
+    val url = transacter.transaction { session ->
+      val backfillRun = session.loadOrNull<DbBackfillRun>(Id(id))
+          ?: throw BadRequestException("backfill $id doesn't exist")
+      viewLogsUrlProvider.getUrl(session, backfillRun)
+    }
+    return Response(
+        body = "go to $url".toResponseBody(),
+        statusCode = HttpURLConnection.HTTP_MOVED_TEMP,
+        headers = Headers.headersOf("Location", url)
+    )
+  }
+}

--- a/service/src/main/kotlin/app/cash/backfila/service/BackfilaDevelopmentService.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/BackfilaDevelopmentService.kt
@@ -1,10 +1,12 @@
 package app.cash.backfila.service
 
 import app.cash.backfila.client.BackfilaDefaultEndpointConfigModule
+import app.cash.backfila.dashboard.ViewLogsUrlProvider
 import misk.MiskApplication
 import misk.MiskCaller
 import misk.MiskRealServiceModule
 import misk.environment.Environment
+import misk.hibernate.Session
 import misk.inject.KAbstractModule
 import misk.jdbc.DataSourceClusterConfig
 import misk.jdbc.DataSourceClustersConfig
@@ -30,6 +32,7 @@ fun main(args: Array<String>) {
           multibind<MiskCallerAuthenticator>().to<FakeCallerAuthenticator>()
           bind<MiskCaller>().annotatedWith<DevelopmentOnly>()
               .toInstance(MiskCaller(user = "testfila"))
+          bind<ViewLogsUrlProvider>().to<DevelopmentViewLogsUrlProvider>()
         }
       },
       BackfilaServiceModule(
@@ -55,4 +58,10 @@ fun main(args: Array<String>) {
       BackfilaDefaultEndpointConfigModule(),
       MiskRealServiceModule()
   ).run(args)
+}
+
+class DevelopmentViewLogsUrlProvider : ViewLogsUrlProvider {
+  override fun getUrl(session: Session, backfillRun: DbBackfillRun): String {
+    return "/"
+  }
 }

--- a/service/web/tabs/app/src/containers/BackfillStatusContainer.tsx
+++ b/service/web/tabs/app/src/containers/BackfillStatusContainer.tsx
@@ -245,6 +245,13 @@ class BackfillStatusContainer extends React.Component<
                     {status.created_by_user}
                   </td>
                 </tr>
+                <tr>
+                  <td colSpan={2}>
+                    <a href={`/backfills/${this.id}/view-logs`}>
+                      View Logs
+                    </a>
+                  </td>
+                </tr>
                 {status.parameters.length > 0 && (
                   <tr>
                     <td colSpan={2} style={{ textAlign: "center" }}>


### PR DESCRIPTION
A provider is bound to have different urls generated per user

I think you guys have it harder - monorepo and misk services have different log urls. Not sure how to make that work other than hard coding them.. or basing it on envoy/http connector as a hack