### PR TITLE
Add stack trace to runbatch response

### DIFF
--- a/client/src/main/proto/app/cash/backfila/client_service.proto
+++ b/client/src/main/proto/app/cash/backfila/client_service.proto
@@ -104,6 +104,8 @@ message RunBatchResponse {
   optional uint64 backoff_ms = 1;
 
   optional PipelinedData pipelined_data = 2;
+
+  optional string exception_stack_trace = 3;
 }
 
 // Pipelined data can be any format as long as both the consumer and provider agree on it.


### PR DESCRIPTION
So we can show it in UI / event log, I don't think we can get a useful trace from a 500