### PR TITLE
Remove annotation based map

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/client/ConnectorProvider.kt
+++ b/service/src/main/kotlin/app/cash/backfila/client/ConnectorProvider.kt
@@ -1,13 +1,13 @@
 package app.cash.backfila.client
 
-import javax.inject.Inject
-import javax.inject.Singleton
 import misk.exceptions.BadRequestException
 
-@Singleton
-class ConnectorProvider @Inject constructor(
-  @ForConnectors private val connectors: Map<String, BackfilaClientServiceClientProvider>
+class ConnectorProvider constructor(
+  private val connectors: Map<String, BackfilaClientServiceClientProvider>
 ) {
+  constructor(vararg connectors: Pair<String, BackfilaClientServiceClientProvider>)
+      : this(connectors.toMap())
+
   fun clientProvider(connectorType: String) =
       connectors[connectorType] ?: throw BadRequestException(
           "Client has unknown connector type: `$connectorType`")

--- a/service/src/main/kotlin/app/cash/backfila/client/ForConnectors.kt
+++ b/service/src/main/kotlin/app/cash/backfila/client/ForConnectors.kt
@@ -1,6 +1,0 @@
-package app.cash.backfila.client
-
-import javax.inject.Qualifier
-
-@Qualifier
-annotation class ForConnectors

--- a/service/src/main/kotlin/app/cash/backfila/service/BackfilaServiceModule.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/BackfilaServiceModule.kt
@@ -1,10 +1,9 @@
 package app.cash.backfila.service
 
 import app.cash.backfila.api.ServiceWebActionsModule
-import app.cash.backfila.client.BackfilaClientServiceClientProvider
+import app.cash.backfila.client.ConnectorProvider
 import app.cash.backfila.client.Connectors
 import app.cash.backfila.client.EnvoyClientServiceClientProvider
-import app.cash.backfila.client.ForConnectors
 import app.cash.backfila.client.HttpClientServiceClientProvider
 import app.cash.backfila.dashboard.BackfilaDashboardModule
 import app.cash.backfila.dashboard.BackfilaWebActionsModule
@@ -44,13 +43,6 @@ class BackfilaServiceModule(
 
     install(SchedulerLifecycleServiceModule())
 
-    newMapBinder<String, BackfilaClientServiceClientProvider>(ForConnectors::class)
-        .addBinding(Connectors.HTTP)
-        .to(HttpClientServiceClientProvider::class.java)
-    newMapBinder<String, BackfilaClientServiceClientProvider>(ForConnectors::class)
-        .addBinding(Connectors.ENVOY)
-        .to(EnvoyClientServiceClientProvider::class.java)
-
     newMultibinder<Interceptor>(HttpClientNetworkInterceptor::class)
 
     if (config.slack != null) {
@@ -60,6 +52,15 @@ class BackfilaServiceModule(
     // TODO:mikepaw Require that the Admin Console is installed so it isn't forgotten.
     // something along the lines of requireBinding but works for multibindings.
   }
+
+  @Provides @Singleton
+  fun connectorProvider(
+    httpProvider: HttpClientServiceClientProvider,
+      envoyProvider: EnvoyClientServiceClientProvider
+  ) = ConnectorProvider(
+      Connectors.HTTP to httpProvider,
+      Connectors.ENVOY to envoyProvider
+  )
 
   @Provides @ForBackfilaScheduler @Singleton
   fun backfillRunnerExecutor(): ListeningExecutorService {

--- a/service/src/test/kotlin/app/cash/backfila/BackfilaTestingModule.kt
+++ b/service/src/test/kotlin/app/cash/backfila/BackfilaTestingModule.kt
@@ -2,9 +2,9 @@ package app.cash.backfila
 
 import app.cash.backfila.api.ServiceWebActionsModule
 import app.cash.backfila.client.BackfilaClientServiceClientProvider
+import app.cash.backfila.client.ConnectorProvider
 import app.cash.backfila.client.Connectors
 import app.cash.backfila.client.FakeBackfilaClientServiceClientProvider
-import app.cash.backfila.client.ForConnectors
 import app.cash.backfila.service.BackfilaConfig
 import app.cash.backfila.service.BackfilaDb
 import app.cash.backfila.service.BackfilaPersistenceModule
@@ -64,14 +64,15 @@ internal class BackfilaTestingModule : KAbstractModule() {
         bindSeedData(MiskCaller::class)
       }
     })
-
-    newMapBinder<String, BackfilaClientServiceClientProvider>(ForConnectors::class)
-        .addBinding(Connectors.HTTP)
-        .to(FakeBackfilaClientServiceClientProvider::class.java)
-    newMapBinder<String, BackfilaClientServiceClientProvider>(ForConnectors::class)
-        .addBinding(Connectors.ENVOY)
-        .to(FakeBackfilaClientServiceClientProvider::class.java)
   }
+
+  @Provides @Singleton
+  fun connectorProvider(
+    testClientProvider: FakeBackfilaClientServiceClientProvider
+  ) = ConnectorProvider(
+      Connectors.HTTP to testClientProvider,
+      Connectors.ENVOY to testClientProvider
+  )
 
   @Provides @ForBackfilaScheduler @Singleton
   fun backfillRunnerExecutor(): ListeningExecutorService {


### PR DESCRIPTION
Preparatory refactor before extracting the endpoint serialization into Misk. 

Makes injection of connectors simpler, without use of additional annotation and multimap.