### PR TITLE
Embedded Backfila can create runs taking parameters as POKO

### DIFF
--- a/client-misk/src/main/kotlin/app/cash/backfila/client/misk/internal/BackfilaParameters.kt
+++ b/client-misk/src/main/kotlin/app/cash/backfila/client/misk/internal/BackfilaParameters.kt
@@ -2,7 +2,6 @@ package app.cash.backfila.client.misk.internal
 
 import app.cash.backfila.client.misk.Backfill
 import app.cash.backfila.client.misk.BackfillConfig
-import app.cash.backfila.client.misk.internal.BackfilaParametersOperator.Companion.TYPE_CONVERTERS
 import app.cash.backfila.protos.service.Parameter
 import com.google.inject.TypeLiteral
 import com.squareup.moshi.Types
@@ -15,9 +14,8 @@ import kotlin.reflect.jvm.jvmErasure
 import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
 
-inline fun <reified T : Any> parametersToBytes(parameters: T): Map<String, ByteString> {
-  val parametersClass = T::class
-
+fun parametersToBytes(parameters: Any): Map<String, ByteString> {
+  val parametersClass = parameters::class
   val map = mutableMapOf<String, ByteString>()
 
   for (property in parametersClass.memberProperties) {

--- a/client-misk/src/test/kotlin/app/cash/backfila/client/misk/hibernate/SinglePartitionHibernateBackfillTest.kt
+++ b/client-misk/src/test/kotlin/app/cash/backfila/client/misk/hibernate/SinglePartitionHibernateBackfillTest.kt
@@ -250,7 +250,7 @@ abstract class SinglePartitionHibernateBackfillTest {
     assertThat(dryRun.backfill.idsRanDry).containsExactlyElementsOf(wetRun.backfill.idsRanWet)
   }
 
-  @Test fun parameters() {
+  @Test fun parametersAsMap() {
     createSome()
     val run = backfila.createDryRun<SinglePartitionHibernateTestBackfill>(
         parameterData = mapOf(
@@ -259,6 +259,18 @@ abstract class SinglePartitionHibernateBackfillTest {
         )
     )
         .apply { configureForTest() }
+
+    run.execute()
+    assertThat(run.backfill.parametersLog).contains(
+        ShapeParameters("blue", "square")
+    )
+  }
+
+  @Test fun parametersAsPoko() {
+    createSome()
+    val run = backfila.createDryRun<SinglePartitionHibernateTestBackfill>(
+        parameters = ShapeParameters("blue", "square")
+    ).apply { configureForTest() }
 
     run.execute()
     assertThat(run.backfill.parametersLog).contains(


### PR DESCRIPTION
The recent change to make parameters representable to backfill implementors as a POKO instead of a map is great! This PR makes a tweak to support specifying parameters as a POKO when creating backfill instances in tests. 