### PR TITLE
A bit more refactoring to separate the hibernate client implementation.

### DIFF
--- a/client-misk/src/main/kotlin/app/cash/backfila/client/misk/HibernateBackfilaClientModule.kt
+++ b/client-misk/src/main/kotlin/app/cash/backfila/client/misk/HibernateBackfilaClientModule.kt
@@ -1,0 +1,42 @@
+package app.cash.backfila.client.misk
+
+import app.cash.backfila.client.misk.internal.BackfillOperator
+import app.cash.backfila.client.misk.internal.HibernateBackfillOperator
+import com.google.inject.Binder
+import com.google.inject.TypeLiteral
+import com.google.inject.multibindings.MapBinder
+import kotlin.reflect.KClass
+import kotlin.reflect.jvm.jvmName
+import misk.inject.KAbstractModule
+
+class HibernateBackfilaClientModule() : KAbstractModule() {
+  override fun configure() {
+    multibind<BackfillOperator.Backend>().to<HibernateBackfillOperator.HibernateBackend>()
+
+    mapBinder(binder()) // Default the mapbinder to having no Backfills registered.
+  }
+}
+
+class HibernateBackfillInstallModule<T : Backfill<*, *, *>> private constructor(
+  private val backfillClass: KClass<T>
+) : KAbstractModule() {
+  override fun configure() {
+    mapBinder(binder()).addBinding(backfillClass.jvmName).toInstance(backfillClass)
+  }
+
+  companion object {
+    inline fun <reified T : Backfill<*, *, *>> create(): HibernateBackfillInstallModule<T> = create(T::class)
+
+    @JvmStatic
+    fun <T : Backfill<*, *, *>> create(backfillClass: KClass<T>): HibernateBackfillInstallModule<T> {
+      return HibernateBackfillInstallModule(backfillClass)
+    }
+  }
+}
+
+private fun mapBinder(binder: Binder) = MapBinder.newMapBinder(
+    binder,
+    object : TypeLiteral<String>() {},
+    object : TypeLiteral<KClass<out Backfill<*, *, *>>>() {},
+    ForBackfila::class.java
+)

--- a/client-misk/src/main/kotlin/app/cash/backfila/client/misk/embedded/Backfila.kt
+++ b/client-misk/src/main/kotlin/app/cash/backfila/client/misk/embedded/Backfila.kt
@@ -1,6 +1,5 @@
 package app.cash.backfila.client.misk.embedded
 
-import app.cash.backfila.client.misk.Backfill
 import app.cash.backfila.client.misk.internal.parametersToBytes
 import app.cash.backfila.protos.service.ConfigureServiceRequest
 import kotlin.reflect.KClass
@@ -11,14 +10,14 @@ import okio.ByteString
  * the Backfila dashboard UI.
  */
 interface Backfila {
-  fun <Type : Backfill<*, *, *>> createDryRun(
+  fun <Type : Any> createDryRun(
     backfill: KClass<Type>,
     parameters: Map<String, ByteString>,
     rangeStart: String?,
     rangeEnd: String?
   ): BackfillRun<Type>
 
-  fun <Type : Backfill<*, *, *>> createWetRun(
+  fun <Type : Any> createWetRun(
     backfillType: KClass<Type>,
     parameters: Map<String, ByteString>,
     rangeStart: String?,
@@ -28,7 +27,7 @@ interface Backfila {
   val configureServiceData: ConfigureServiceRequest?
 }
 
-inline fun <reified Type : Backfill<*, *, *>> Backfila.createDryRun(
+inline fun <reified Type : Any> Backfila.createDryRun(
   parameters: Any? = null,
   parameterData: Map<String, ByteString> = mapOf(),
   rangeStart: String? = null,
@@ -42,7 +41,7 @@ inline fun <reified Type : Backfill<*, *, *>> Backfila.createDryRun(
   return createDryRun(Type::class, parameterBytes, rangeStart, rangeEnd)
 }
 
-inline fun <reified Type : Backfill<*, *, *>> Backfila.createWetRun(
+inline fun <reified Type : Any> Backfila.createWetRun(
   parameters: Any? = null,
   parameterData: Map<String, ByteString> = mapOf(),
   rangeStart: String? = null,

--- a/client-misk/src/main/kotlin/app/cash/backfila/client/misk/embedded/BackfillRun.kt
+++ b/client-misk/src/main/kotlin/app/cash/backfila/client/misk/embedded/BackfillRun.kt
@@ -1,6 +1,5 @@
 package app.cash.backfila.client.misk.embedded
 
-import app.cash.backfila.client.misk.Backfill
 import app.cash.backfila.client.misk.internal.BatchSnapshot
 import app.cash.backfila.client.misk.internal.PartitionCursor
 import app.cash.backfila.protos.clientservice.GetNextBatchRangeResponse
@@ -10,7 +9,7 @@ import okio.ByteString
 /**
  * Get an instance of this from [Backfila].
  */
-interface BackfillRun<B : Backfill<*, *, *>> {
+interface BackfillRun<B : Any> {
   val backfill: B
   val dryRun: Boolean
   val parameters: Map<String, ByteString>

--- a/client-misk/src/main/kotlin/app/cash/backfila/client/misk/internal/BackfilaParameters.kt
+++ b/client-misk/src/main/kotlin/app/cash/backfila/client/misk/internal/BackfilaParameters.kt
@@ -22,29 +22,11 @@ fun parametersToBytes(parameters: Any): Map<String, ByteString> {
   return map
 }
 
-private fun <T : Any> parametersClass(backfillClass: KClass<out Backfill<*, *, T>>): KClass<T> {
-  // Like MyBackfill.
-  val thisType = TypeLiteral.get(backfillClass.java)
-
-  // Like Backfill<E, Id<E>, MyDataClass>.
-  val supertype = thisType.getSupertype(Backfill::class.java).type as ParameterizedType
-
-  // Like MyDataClass
-  return (Types.getRawType(supertype.actualTypeArguments[2]) as Class<T>).kotlin
-}
-
 internal class BackfilaParametersOperator<T : Any>(
-  backfillClass: KClass<out Backfill<*, *, T>>
+  val parametersClass: KClass<T>
 ) {
-  val parametersClass: KClass<T> = parametersClass(backfillClass)
-
-  /** Constructor parameters to create a new T. */
-  val constructorParameters: List<KParameter>
-
-  init {
-    constructorParameters = parametersClass.primaryConstructor!!.parameters
-    // TODO check parameters
-  }
+  /** Constructor parameters used as defaults when missing to create a new T. */
+  val constructorParameters: List<KParameter> = parametersClass.primaryConstructor!!.parameters
 
   fun constructBackfillConfig(
     parameters: MutableMap<String, ByteString>,
@@ -67,9 +49,7 @@ internal class BackfilaParametersOperator<T : Any>(
         Int::class to { value: ByteString -> value.utf8().toInt() }
     )
 
-    internal inline fun <reified T : Any> backfilaParametersForBackfill(backfillClass: KClass<Backfill<*, *, T>>): List<Parameter> {
-      val parametersClass = parametersClass(backfillClass)
-
+    internal inline fun <reified T : Any> backfilaParametersFromClass(parametersClass: KClass<T>): List<Parameter> {
       // Validate that we can handle the parameters if they are specified.
       for (parameter in parametersClass.primaryConstructor!!.parameters) {
         check(parameter.type.jvmErasure in TYPE_CONVERTERS.keys) {

--- a/client-misk/src/main/kotlin/app/cash/backfila/client/misk/internal/BackfilaParameters.kt
+++ b/client-misk/src/main/kotlin/app/cash/backfila/client/misk/internal/BackfilaParameters.kt
@@ -1,12 +1,8 @@
 package app.cash.backfila.client.misk.internal
 
-import app.cash.backfila.client.misk.Backfill
 import app.cash.backfila.client.misk.BackfillConfig
 import app.cash.backfila.client.misk.Description
 import app.cash.backfila.protos.service.Parameter
-import com.google.inject.TypeLiteral
-import com.squareup.moshi.Types
-import java.lang.reflect.ParameterizedType
 import kotlin.reflect.KClass
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.memberProperties

--- a/client-misk/src/main/kotlin/app/cash/backfila/client/misk/internal/BackfillOperator.kt
+++ b/client-misk/src/main/kotlin/app/cash/backfila/client/misk/internal/BackfillOperator.kt
@@ -25,7 +25,14 @@ interface BackfillOperator {
   /** Service provider interface for backends like Hibernate and DynamoDb. */
   interface Backend {
     fun create(backfillName: String, backfillId: String): BackfillOperator?
+    fun backfills(): Set<BackfillRegistration>
   }
+
+  data class BackfillRegistration(
+    val name: String,
+    val description: String?,
+    val parametersClass: KClass<Any>
+  )
 
   @Singleton
   class Factory @Inject constructor(

--- a/client-misk/src/main/kotlin/app/cash/backfila/client/misk/internal/BackfillOperator.kt
+++ b/client-misk/src/main/kotlin/app/cash/backfila/client/misk/internal/BackfillOperator.kt
@@ -11,6 +11,7 @@ import com.google.common.cache.CacheBuilder
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.reflect.KClass
 import misk.exceptions.BadRequestException
 import misk.logging.getLogger
 

--- a/client-misk/src/main/kotlin/app/cash/backfila/client/misk/internal/EmbeddedBackfila.kt
+++ b/client-misk/src/main/kotlin/app/cash/backfila/client/misk/internal/EmbeddedBackfila.kt
@@ -2,7 +2,6 @@ package app.cash.backfila.client.misk.internal
 
 import app.cash.backfila.client.BackfilaApi
 import app.cash.backfila.client.Connectors
-import app.cash.backfila.client.misk.Backfill
 import app.cash.backfila.client.misk.embedded.Backfila
 import app.cash.backfila.client.misk.embedded.BackfillRun
 import app.cash.backfila.protos.service.ConfigureServiceRequest
@@ -53,7 +52,7 @@ internal class EmbeddedBackfila @Inject internal constructor(
     val backfillId = backfillIdGenerator.getAndIncrement()
     val operator = operatorFactory.create(createRequest.backfill_name, backfillId.toString())
 
-    val run = EmbeddedBackfillRun<Backfill<*, *, *>>(
+    val run = EmbeddedBackfillRun<Any>(
         operator = operator,
         dryRun = createRequest.dry_run,
         parameters = createRequest.parameter_map,
@@ -66,21 +65,21 @@ internal class EmbeddedBackfila @Inject internal constructor(
     return Calls.response(CreateAndStartBackfillResponse(backfillId.toLong()))
   }
 
-  override fun <Type : Backfill<*, *, *>> createDryRun(
+  override fun <Type : Any> createDryRun(
     backfill: KClass<Type>,
     parameters: Map<String, ByteString>,
     rangeStart: String?,
     rangeEnd: String?
   ) = createBackfill(backfill, true, parameters, rangeStart, rangeEnd)
 
-  override fun <Type : Backfill<*, *, *>> createWetRun(
+  override fun <Type : Any> createWetRun(
     backfillType: KClass<Type>,
     parameters: Map<String, ByteString>,
     rangeStart: String?,
     rangeEnd: String?
   ) = createBackfill(backfillType, false, parameters, rangeStart, rangeEnd)
 
-  private fun <Type : Backfill<*, *, *>> createBackfill(
+  private fun <Type : Any> createBackfill(
     backfillType: KClass<Type>,
     dryRun: Boolean,
     parameters: Map<String, ByteString>,

--- a/client-misk/src/main/kotlin/app/cash/backfila/client/misk/internal/EmbeddedBackfillRun.kt
+++ b/client-misk/src/main/kotlin/app/cash/backfila/client/misk/internal/EmbeddedBackfillRun.kt
@@ -1,6 +1,5 @@
 package app.cash.backfila.client.misk.internal
 
-import app.cash.backfila.client.misk.Backfill
 import app.cash.backfila.client.misk.embedded.BackfillRun
 import app.cash.backfila.protos.clientservice.GetNextBatchRangeRequest
 import app.cash.backfila.protos.clientservice.GetNextBatchRangeResponse
@@ -18,7 +17,7 @@ import okio.ByteString.Companion.encodeUtf8
  *
  * This is not thread safe.
  */
-internal class EmbeddedBackfillRun<B : Backfill<*, *, *>>(
+internal class EmbeddedBackfillRun<B : Any>(
   private val operator: BackfillOperator,
   override val dryRun: Boolean,
   override val parameters: Map<String, ByteString>,

--- a/client-misk/src/test/kotlin/app/cash/backfila/client/misk/ClientMiskTestServiceConfig.kt
+++ b/client-misk/src/test/kotlin/app/cash/backfila/client/misk/ClientMiskTestServiceConfig.kt
@@ -27,7 +27,7 @@ fun main(args: Array<String>) {
       ),
       object : KAbstractModule() {
         override fun configure() {
-          install(BackfillInstallModule.create<SinglePartitionHibernateTestBackfill>())
+          install(HibernateBackfillInstallModule.create<SinglePartitionHibernateTestBackfill>())
         }
       },
       BackfilaClientModule(),

--- a/client-misk/src/test/kotlin/app/cash/backfila/client/misk/ClientMiskTestingModule.kt
+++ b/client-misk/src/test/kotlin/app/cash/backfila/client/misk/ClientMiskTestingModule.kt
@@ -62,8 +62,8 @@ internal class ClientMiskTestingModule(
     bind(BackfilaClientLoggingSetupProvider::class.java)
         .to(BackfilaClientNoLoggingSetupProvider::class.java)
 
-    install(BackfillInstallModule.create<SinglePartitionHibernateTestBackfill>())
-    install(BackfillInstallModule.create<ChickenToBeefBackfill>())
-    install(BackfillInstallModule.create<RecordNoParametersConfigValuesBackfill>())
+    install(HibernateBackfillInstallModule.create<SinglePartitionHibernateTestBackfill>())
+    install(HibernateBackfillInstallModule.create<ChickenToBeefBackfill>())
+    install(HibernateBackfillInstallModule.create<RecordNoParametersConfigValuesBackfill>())
   }
 }


### PR DESCRIPTION
This allows the client implemetations to use any kind of class they
wish and separates the installing of the client implementation from the
base communication to/from backfila.

There is still a todo to separate this in the
BackfilaStartupConfigurator but that will be in a follow-up.