### PR TITLE
Support publishing 2 classifiers from backfila/service

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -68,6 +68,7 @@ jar {
     attributes 'Main-Class': 'app.cash.backfila.service.BackfilaServiceKt'
   }
   zip64 = true
+  classifier = 'unshaded'
 }
 
 shadowJar {


### PR DESCRIPTION
The unshaded artifact is the library, the shadowJar is standalone.