### PR TITLE
make baseurl with subpath in it works to better support other clients

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/client/HttpClientServiceApi.kt
+++ b/service/src/main/kotlin/app/cash/backfila/client/HttpClientServiceApi.kt
@@ -41,6 +41,6 @@ interface HttpClientServiceApi {
   ): RunBatchResponse
 
   companion object {
-    private const val BASE_PATH = "/backfila"
+    private const val BASE_PATH = "backfila"
   }
 }


### PR DESCRIPTION
what happened at the moment.

Take `prepareBackfill` as an example.

What happen now:
service url: `https://example.com/sub-path/` + `/backfila/prepare-backfil` (from Retrofit annotation) = `https://example.com/backfila/prepare-backfill`

After the change
service url: `https://example.com/sub-path/` + `backfila/prepare-backfil` (from Retrofit annotation) = `https://example.com/sub-path/backfila/prepare-backfill`

this will make it easy to integrate with other clients that mounts the backfila endpoint under different subpaths.
