### PR TITLE
Adds a no-op task that runs before it tries to hunt for a lease.

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/service/scheduler/RunnerSchedulerService.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/scheduler/RunnerSchedulerService.kt
@@ -37,6 +37,10 @@ class RunnerSchedulerService @Inject constructor(
 
   override fun run() {
     while (running) {
+      // once the noop runs there is space for another runner
+      runnerExecutorService.submit { "noop task" }.get()
+      if (!running) break; // We stopped running while waiting for an open runner thread.
+
       val newRunners = leaseHunter.hunt()
 
       newRunners.forEach(::addRunner)


### PR DESCRIPTION
This will prevent a busy backfill node from attempting to take a lease.