### PR TITLE
Switch to runBlockingTest for test coroutines

### DIFF
--- a/service/src/test/kotlin/app/cash/backfila/service/RunBlockingTestCancellable.kt
+++ b/service/src/test/kotlin/app/cash/backfila/service/RunBlockingTestCancellable.kt
@@ -1,0 +1,24 @@
+package app.cash.backfila.service
+
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
+
+/**
+ * Same as runBlocking but cancels the coroutines if an exception is thrown.
+ * runBlockingTest has a bug where it hangs instead:
+ * https://github.com/Kotlin/kotlinx.coroutines/issues/1910
+ */
+@Suppress("EXPERIMENTAL_API_USAGE")
+internal fun runBlockingTestCancellable(
+  testBody: suspend TestCoroutineScope.() -> Unit
+) {
+  runBlockingTest {
+    try {
+      this.testBody()
+    } catch (t: Throwable) {
+      coroutineContext.cancel()
+      throw t
+    }
+  }
+}


### PR DESCRIPTION
This replaces delays with fake delays and now the coroutines run in the same scope so everything is deterministic. In some places we no longer need to wait since the test coroutine only wakes up when the runner coroutine has done its work