### PR TITLE
Quickfix: Switch EmbeddedBackfilaModule back to a KAbstractModule

### DIFF
--- a/backfila-embedded/build.gradle.kts
+++ b/backfila-embedded/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
   implementation(Dependencies.kotlinStdLib)
   implementation(Dependencies.retrofit)
   implementation(Dependencies.retrofitMock)
+  implementation(Dependencies.miskInject)
 
   api(project(":client"))
   implementation(project(":client-base"))

--- a/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/EmbeddedBackfilaModule.kt
+++ b/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/EmbeddedBackfilaModule.kt
@@ -3,14 +3,15 @@ package app.cash.backfila.embedded
 import app.cash.backfila.client.BackfilaApi
 import app.cash.backfila.client.internal.EmbeddedBackfila
 import com.google.inject.AbstractModule
+import misk.inject.KAbstractModule
 
 /**
  * Use this to connect to an embedded Backfila implementation in development or testing. You will
  * also need to install a [BackfillModule].
  */
-class EmbeddedBackfilaModule : AbstractModule() {
+class EmbeddedBackfilaModule : KAbstractModule() {
   override fun configure() {
-    bind(BackfilaApi::class.java).to(EmbeddedBackfila::class.java)
-    bind(Backfila::class.java).to(EmbeddedBackfila::class.java)
+    bind<BackfilaApi>().to<EmbeddedBackfila>()
+    bind<Backfila>().to<EmbeddedBackfila>()
   }
 }

--- a/client-misk/src/main/kotlin/app/cash/backfila/client/misk/BackfillModule.kt
+++ b/client-misk/src/main/kotlin/app/cash/backfila/client/misk/BackfillModule.kt
@@ -29,6 +29,7 @@ import kotlin.reflect.KClass
  *       [EmbeddedBackfilaModule] (testing and development)
  *       or [BackfilaClientModule] (staging and production).
  */
+// TODO(keefer+mikepaw): Move this into backfila-client and add a new MiskBackfillModule.
 class BackfillModule @JvmOverloads constructor(
   private val config: BackfilaClientConfig,
   private val loggingSetupProvider: KClass<out BackfilaClientLoggingSetupProvider> =


### PR DESCRIPTION
EmbeddedBackfilaModule needs to be a `KAbstractModule` because misk idioms (e.g. `fun applicationModules(...): List<KAbstractModule>`) use a list of `KAbstractModule` for application modules, and `AbstractModule` does not fit those type constraints.