### PR TITLE
Expose client-base api through client-misk

### DIFF
--- a/client-misk/build.gradle.kts
+++ b/client-misk/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
   implementation(Dependencies.loggingApi)
 
   api(project(":client"))
-  implementation(project(":client-base"))
+  api(project(":client-base"))
 
   implementation(Dependencies.misk)
   implementation(Dependencies.miskActions)


### PR DESCRIPTION
Exposing `client-base` as an api of `client-misk` allows users of the client not to explicitly add both dependencies. `client-misk` will transitively pull in `client-base` and make its classes available to dependants.

i.e. to upgrade to the new backfila client rather than:

```kt
implementation(Dependencies.backfilaClientMisk)
implementation(Dependencies.backfilaClientBase)
```

you'll only require

```kt
implementation(Dependencies.backfilaClientMisk)
```