### PR TITLE
Expose client-misk through client-misk-dynamodb

### DIFF
--- a/client-misk-dynamodb/build.gradle.kts
+++ b/client-misk-dynamodb/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
   api(project(":client"))
   implementation(project(":client-base"))
   // TODO: should not depend on misk
-  implementation(project(":client-misk"))
+  api(project(":client-misk"))
 
   testImplementation(Dependencies.assertj)
   testImplementation(Dependencies.awsDynamodb)


### PR DESCRIPTION
Unlike `client-misk-{hibernate,jooq}`, the misk dynamodb client lists
`client-misk` as an implementation detail, and does not expose its API.
This appears to be error.

Following this change, dependents of `client-misk-dynamodb` will not need
to also explicitly depend on `client-misk`.