### PR TITLE
Add API for finalize and client stub

### DIFF
--- a/client-base/src/main/kotlin/app/cash/backfila/client/spi/BackfilaClientServiceHandler.kt
+++ b/client-base/src/main/kotlin/app/cash/backfila/client/spi/BackfilaClientServiceHandler.kt
@@ -3,16 +3,17 @@ package app.cash.backfila.client.spi
 import app.cash.backfila.client.BackfilaClientLoggingSetupProvider
 import app.cash.backfila.client.UnknownBackfillException
 import app.cash.backfila.client.internal.BackfillOperatorFactory
+import app.cash.backfila.protos.clientservice.FinalizeBackfillRequest
+import app.cash.backfila.protos.clientservice.FinalizeBackfillResponse
 import app.cash.backfila.protos.clientservice.GetNextBatchRangeRequest
 import app.cash.backfila.protos.clientservice.GetNextBatchRangeResponse
 import app.cash.backfila.protos.clientservice.PrepareBackfillRequest
 import app.cash.backfila.protos.clientservice.PrepareBackfillResponse
 import app.cash.backfila.protos.clientservice.RunBatchRequest
 import app.cash.backfila.protos.clientservice.RunBatchResponse
+import javax.inject.Inject
 import org.apache.commons.lang3.exception.ExceptionUtils
 import wisp.logging.getLogger
-import javax.inject.Inject
-import kotlin.jvm.Throws
 
 /**
  * The various Backfila ClientService implementations invoke this from their service handlers to get
@@ -79,6 +80,16 @@ class BackfilaClientServiceHandler @Inject constructor(
           .exception_stack_trace(ExceptionUtils.getStackTrace(exception))
           .build()
       }
+    }
+  }
+
+  @Throws(UnknownBackfillException::class)
+  fun finalizeBackfill(request: FinalizeBackfillRequest): FinalizeBackfillResponse {
+    return loggingSetupProvider.withBackfillRunLogging(request.backfill_name, request.backfill_id) {
+      logger.info { "Finalizing backfill `${request.backfill_name}::${request.backfill_id}`" }
+
+      // This is a stub for now
+      return@withBackfillRunLogging FinalizeBackfillResponse()
     }
   }
 

--- a/client-misk/src/main/kotlin/app/cash/backfila/client/misk/client/BackfilaMiskClientModule.kt
+++ b/client-misk/src/main/kotlin/app/cash/backfila/client/misk/client/BackfilaMiskClientModule.kt
@@ -1,8 +1,9 @@
 package app.cash.backfila.client.misk.client
 
 import app.cash.backfila.client.BackfilaApi
-import app.cash.backfila.client.misk.MiskBackfillModule
 import app.cash.backfila.client.ForBackfila
+import app.cash.backfila.client.misk.MiskBackfillModule
+import app.cash.backfila.client.misk.internal.FinalizeBackfillAction
 import app.cash.backfila.client.misk.internal.GetNextBatchRangeAction
 import app.cash.backfila.client.misk.internal.PrepareBackfillAction
 import app.cash.backfila.client.misk.internal.RunBatchAction
@@ -33,6 +34,7 @@ class BackfilaMiskClientModule : KAbstractModule() {
     install(WebActionModule.create<PrepareBackfillAction>())
     install(WebActionModule.create<GetNextBatchRangeAction>())
     install(WebActionModule.create<RunBatchAction>())
+    install(WebActionModule.create<FinalizeBackfillAction>())
   }
 
   @Provides @ForBackfila internal fun wireRetrofitBuilder() =

--- a/client-misk/src/main/kotlin/app/cash/backfila/client/misk/internal/BackfilaWebApiActions.kt
+++ b/client-misk/src/main/kotlin/app/cash/backfila/client/misk/internal/BackfilaWebApiActions.kt
@@ -2,14 +2,16 @@ package app.cash.backfila.client.misk.internal
 
 import app.cash.backfila.client.UnknownBackfillException
 import app.cash.backfila.client.spi.BackfilaClientServiceHandler
+import app.cash.backfila.protos.clientservice.FinalizeBackfillRequest
+import app.cash.backfila.protos.clientservice.FinalizeBackfillResponse
 import app.cash.backfila.protos.clientservice.GetNextBatchRangeRequest
 import app.cash.backfila.protos.clientservice.GetNextBatchRangeResponse
 import app.cash.backfila.protos.clientservice.PrepareBackfillRequest
 import app.cash.backfila.protos.clientservice.PrepareBackfillResponse
 import app.cash.backfila.protos.clientservice.RunBatchRequest
 import app.cash.backfila.protos.clientservice.RunBatchResponse
-import misk.exceptions.BadRequestException
 import javax.inject.Inject
+import misk.exceptions.BadRequestException
 import misk.security.authz.Authenticated
 import misk.web.AvailableWhenDegraded
 import misk.web.Post
@@ -55,6 +57,19 @@ internal class RunBatchAction @Inject constructor(
   @AvailableWhenDegraded
   fun runBatch(@RequestBody request: RunBatchRequest): RunBatchResponse =
     wrapExceptions { clientServiceHandler.runBatch(request) }
+}
+
+internal class FinalizeBackfillAction @Inject constructor(
+  private val clientServiceHandler: BackfilaClientServiceHandler,
+) : WebAction {
+  @Post("/backfila/finalize-backfill")
+  @RequestContentType(MediaTypes.APPLICATION_PROTOBUF)
+  @ResponseContentType(MediaTypes.APPLICATION_PROTOBUF)
+  @Authenticated(services = ["backfila"])
+  @LogRequestResponse(bodySampling = 1.0, errorBodySampling = 1.0)
+  @AvailableWhenDegraded
+  fun finalizeBackfill(@RequestBody request: FinalizeBackfillRequest): FinalizeBackfillResponse =
+    wrapExceptions { clientServiceHandler.finalizeBackfill(request) }
 }
 
 private fun <R> wrapExceptions(

--- a/client/src/main/proto/app/cash/backfila/client_service.proto
+++ b/client/src/main/proto/app/cash/backfila/client_service.proto
@@ -131,3 +131,22 @@ message PipelinedData {
 message PipelinedRecord {
   optional bytes data = 1;
 }
+
+message FinalizeBackfillRequest {
+  optional string backfill_id = 1;
+  optional string backfill_name = 2;
+  map<string, bytes> parameters = 3;
+  optional bool dry_run = 4;
+  // Indicates what caused the backfill to finalize.
+  optional FinalizeState finalize_state = 5;
+
+  enum FinalizeState {
+    // The backfill completed normally.
+    COMPLETED = 1;
+    // The backfill was failed permanently by a user.
+    FAILED = 2;
+  }
+}
+
+message FinalizeBackfillResponse {
+}


### PR DESCRIPTION
Just adding a stub so we can deploy this on clients and the service can start calling it without 404ing

Service changes will come later - not adding the operator functions yet so people don't implement this in their backfills expecting it to work