### PR TITLE
Move shadowJar plugin to classpath

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
   repositories {
+    gradlePluginPortal()
     mavenCentral()
   }
 
@@ -16,6 +17,7 @@ buildscript {
     classpath(Dependencies.mavenPublishGradlePlugin)
     classpath(Dependencies.spotlessPlugin)
     classpath(Dependencies.wireGradlePlugin)
+    classpath(Dependencies.shadowJarPlugin)
   }
 }
 

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("com.github.johnrengelman.shadow") version "7.1.2"
+  id("com.github.johnrengelman.shadow")
   kotlin("jvm")
   id("com.diffplug.spotless")
 }


### PR DESCRIPTION
This will fix our internal publishing scripts, while keeping the external ones intact.