### PR TITLE
Fix maven publish plugin

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -30,7 +30,7 @@ object Dependencies {
   val kotlinxCoroutinesLogging = "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:${Versions.kotlinCoroutines}"
   val kotlinxCoroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.kotlinCoroutines}"
   val loggingApi = "io.github.microutils:kotlin-logging:1.7.9"
-  val mavenPublishGradlePlugin = "com.vanniktech:gradle-maven-publish-plugin:0.17.0"
+  val mavenPublishGradlePlugin = "com.vanniktech:gradle-maven-publish-plugin:0.19.0"
   val metricsCore = "io.dropwizard.metrics:metrics-core:4.0.2"
   val metricsParent = "io.dropwizard.metrics:metrics-parent:4.0.2"
   val misk = "com.squareup.misk:misk:${Versions.misk}"

--- a/client-base/src/test/java/app/cash/backfila/embedded/JavaToUpperCaseTestBackfill.java
+++ b/client-base/src/test/java/app/cash/backfila/embedded/JavaToUpperCaseTestBackfill.java
@@ -2,6 +2,7 @@ package app.cash.backfila.embedded;
 
 import app.cash.backfila.client.BackfillConfig;
 import app.cash.backfila.client.NoParameters;
+import app.cash.backfila.client.ValidateResult;
 import app.cash.backfila.client.fixedset.FixedSetBackfill;
 import app.cash.backfila.client.fixedset.FixedSetRow;
 import java.util.ArrayList;
@@ -14,15 +15,17 @@ import org.jetbrains.annotations.NotNull;
  * Testing that creating Java backfill classes works. Parameters are not currently supported.
  */
 class JavaToUpperCaseTestBackfill extends FixedSetBackfill<NoParameters> {
-  public List<String> runOrder = new ArrayList();
+  public List<String> runOrder = new ArrayList<>();
 
   @Inject
-  public JavaToUpperCaseTestBackfill(){
+  public JavaToUpperCaseTestBackfill() {
 
   }
 
-  @Override public void checkBackfillConfig(@NotNull BackfillConfig<NoParameters> backfillConfig) {
+  @NotNull @Override
+  public ValidateResult<NoParameters> checkBackfillConfig(@NotNull BackfillConfig<NoParameters> backfillConfig) {
     // No parameters to check
+    return super.checkBackfillConfig(backfillConfig);
   }
 
   @Override public void runOne(@NotNull FixedSetRow row) {

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.tasks.SourcesJar
+
 plugins {
   id("com.squareup.wire")
 }
@@ -40,3 +42,10 @@ if (rootProject.file("hooks.gradle").exists()) {
 }
 
 apply(from = "$rootDir/gradle-mvn-publish.gradle")
+
+// Prevent proto source files from conflicting
+afterEvaluate {
+  tasks.withType<SourcesJar>().configureEach {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+  }
+}


### PR DESCRIPTION
wire duplicates proto files to another directory and gradle was unhappy there were duplicate paths. Not sure why this only started recently