### PR TITLE
Do not sleep after empty/fake batch runs

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/service/runner/statemachine/BatchAwaiter.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/runner/statemachine/BatchAwaiter.kt
@@ -67,9 +67,9 @@ class BatchAwaiter(
           }
 
           if (!backfillRunner.runBatchBackoff.backingOff()) {
-            if (response.backoff_ms ?: 0 > 0) {
+            if ((response.backoff_ms ?: 0) > 0) {
               backfillRunner.runBatchBackoff.addMillis(response.backoff_ms)
-            } else if (backfillRunner.metadata.extraSleepMs > 0) {
+            } else if (backfillRunner.metadata.extraSleepMs > 0 && initialBatch.matching_record_count != 0L) {
               backfillRunner.runBatchBackoff.addMillis(backfillRunner.metadata.extraSleepMs)
             }
           }


### PR DESCRIPTION
When using extra_sleep with a big sparse table, it runs super slow for no good reason

This is because we still "run" empty batches. We don't actually send an RPC, but we forward a fake response to the Awaiter where the cursors can get pushed forward. Otherwise we'd lose a lot of progress on a restart