### PR TITLE
For better startup errors in tests.

### DIFF
--- a/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/internal/EmbeddedBackfila.kt
+++ b/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/internal/EmbeddedBackfila.kt
@@ -133,4 +133,7 @@ internal class EmbeddedBackfila @Inject internal constructor(
       rangeEnd = rangeEnd
     )
   }
+
+  override val throwOnStartup: Boolean
+    get() = true
 }

--- a/client-base/src/main/kotlin/app/cash/backfila/client/BackfilaApi.kt
+++ b/client-base/src/main/kotlin/app/cash/backfila/client/BackfilaApi.kt
@@ -44,4 +44,7 @@ interface BackfilaApi {
   fun checkBackfillStatus(
     @Body request: CheckBackfillStatusRequest
   ): Call<CheckBackfillStatusResponse>
+  
+  val throwOnStartup: Boolean
+    get() = false
 }

--- a/client-base/src/main/kotlin/app/cash/backfila/client/RealBackfillModule.kt
+++ b/client-base/src/main/kotlin/app/cash/backfila/client/RealBackfillModule.kt
@@ -21,8 +21,8 @@ class RealBackfillModule(
   constructor(
     config: BackfilaClientConfig,
     loggingSetupProvider: KClass<out BackfilaClientLoggingSetupProvider> =
-        BackfilaClientNoLoggingSetupProvider::class
-  ) : this( Provider { config }, loggingSetupProvider)
+      BackfilaClientNoLoggingSetupProvider::class
+  ) : this(Provider { config }, loggingSetupProvider)
 
   /**
    * This constructor is used for java land.

--- a/client-base/src/main/kotlin/app/cash/backfila/client/internal/BackfilaClient.kt
+++ b/client-base/src/main/kotlin/app/cash/backfila/client/internal/BackfilaClient.kt
@@ -13,4 +13,6 @@ interface BackfilaClient {
   fun createAndStartBackfill(request: CreateAndStartBackfillRequest): CreateAndStartBackfillResponse
 
   fun checkBackfillStatus(request: CheckBackfillStatusRequest): CheckBackfillStatusResponse
+
+  val throwOnStartup: Boolean
 }

--- a/client-base/src/main/kotlin/app/cash/backfila/client/internal/BackfilaStartupConfigurator.kt
+++ b/client-base/src/main/kotlin/app/cash/backfila/client/internal/BackfilaStartupConfigurator.kt
@@ -61,7 +61,11 @@ class BackfilaStartupConfigurator @Inject constructor(
           "Updated backfila with ${registrations.size} backfills."
       }
     } catch (e: Exception) {
-      logger.error(e) { "Exception making startup call to configure backfila, skipped!" }
+      if (backfilaClient.throwOnStartup) {
+        throw e
+      } else {
+        logger.error(e) { "Exception making startup call to configure backfila, skipped!" }
+      }
     }
   }
 

--- a/client-base/src/main/kotlin/app/cash/backfila/client/internal/RealBackfilaClient.kt
+++ b/client-base/src/main/kotlin/app/cash/backfila/client/internal/RealBackfilaClient.kt
@@ -51,4 +51,7 @@ class RealBackfilaClient @Inject internal constructor(
       throw UncheckedIOException(e)
     }
   }
+
+  override val throwOnStartup: Boolean
+    get() = backfilaApi.throwOnStartup
 }

--- a/service-self-backfill/src/main/kotlin/app/cash/backfila/service/selfbackfill/LocalBackfilaClient.kt
+++ b/service-self-backfill/src/main/kotlin/app/cash/backfila/service/selfbackfill/LocalBackfilaClient.kt
@@ -36,4 +36,7 @@ internal class LocalBackfilaClient @Inject constructor(
     // We don't need this
     TODO("Not yet implemented")
   }
+
+  override val throwOnStartup: Boolean
+    get() = true
 }


### PR DESCRIPTION
I think we only want to skip failing on startup when it is a real
external client. Otherwise we want to fail to make the true error move
visible.