### PR TITLE
Remove jcenter as a repository

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,6 @@ subprojects {
 
   repositories {
     mavenCentral()
-    jcenter()
     maven(url = "https://s3-us-west-2.amazonaws.com/dynamodb-local/release")
   }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
   repositories {
-    gradlePluginPortal()
     mavenCentral()
+    gradlePluginPortal()
   }
 
   dependencies {

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,5 @@
+pluginManagement {
+  repositories {
+    mavenCentral()
+  }
+}


### PR DESCRIPTION
jcenter has been shut down and the build fails to download things from there.