### PR TITLE
Set a limit to the number of run partitions retrieved

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/service/scheduler/LeaseHunter.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/scheduler/LeaseHunter.kt
@@ -29,7 +29,7 @@ class LeaseHunter @Inject constructor(
         .runState(BackfillState.RUNNING)
         .leaseExpiresAtBefore(clock.instant())
         .apply {
-          maxRows = RUN_PARTITION_BATCH_SIZE
+          maxRows = RUN_PARTITION_QUERY_LIMIT
         }
         .list(session)
 
@@ -57,6 +57,6 @@ class LeaseHunter @Inject constructor(
 
   companion object {
     val LEASE_DURATION: Duration = Duration.ofMinutes(5)
-    const val RUN_PARTITION_BATCH_SIZE = 100
+    const val RUN_PARTITION_QUERY_LIMIT = 10_000
   }
 }

--- a/service/src/main/kotlin/app/cash/backfila/service/scheduler/LeaseHunter.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/scheduler/LeaseHunter.kt
@@ -28,6 +28,9 @@ class LeaseHunter @Inject constructor(
       val unleasedPartitions = queryFactory.newQuery<RunPartitionQuery>()
         .runState(BackfillState.RUNNING)
         .leaseExpiresAtBefore(clock.instant())
+        .apply {
+          maxRows = RUN_PARTITION_BATCH_SIZE
+        }
         .list(session)
 
       if (unleasedPartitions.isEmpty()) {
@@ -54,5 +57,6 @@ class LeaseHunter @Inject constructor(
 
   companion object {
     val LEASE_DURATION: Duration = Duration.ofMinutes(5)
+    const val RUN_PARTITION_BATCH_SIZE = 100
   }
 }


### PR DESCRIPTION
Places a limit on the number of unleased partitions to retrieve, to ensure we don't trip the maximum row limit in misk's hibernate module. Went with a lower batch size since we ultimately select one at random