### PR TITLE
Stop using backfill_id in Prepare request and deprecate it

### DIFF
--- a/client-base/src/main/kotlin/app/cash/backfila/client/internal/BackfillOperatorFactory.kt
+++ b/client-base/src/main/kotlin/app/cash/backfila/client/internal/BackfillOperatorFactory.kt
@@ -30,15 +30,20 @@ class BackfillOperatorFactory @Inject constructor(
   @Throws(UnknownBackfillException::class)
   fun create(backfillName: String, backfillId: String): BackfillOperator {
     return instanceCache.get(backfillId) {
-      for (backend in backends) {
-        val backfillOperator = backend.create(backfillName, backfillId)
-        if (backfillOperator != null) {
-          return@get backfillOperator
-        }
-      }
-      logger.warn("Unknown backfill $backfillName, was it deleted while running?")
-      throw UnknownBackfillException("Unknown backfill $backfillName")
+      create(backfillName)
     }
+  }
+
+  @Throws(UnknownBackfillException::class)
+  fun create(backfillName: String): BackfillOperator {
+    for (backend in backends) {
+      val backfillOperator = backend.create(backfillName)
+      if (backfillOperator != null) {
+        return backfillOperator
+      }
+    }
+    logger.warn("Unknown backfill $backfillName, was it deleted while running?")
+    throw UnknownBackfillException("Unknown backfill $backfillName")
   }
 
   companion object {

--- a/client-base/src/main/kotlin/app/cash/backfila/client/internal/EmptyBackend.kt
+++ b/client-base/src/main/kotlin/app/cash/backfila/client/internal/EmptyBackend.kt
@@ -12,7 +12,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class EmptyBackend @Inject constructor() : BackfillBackend {
-  override fun create(backfillName: String, backfillId: String): BackfillOperator? {
+  override fun create(backfillName: String): BackfillOperator? {
     // Registers no backfills so it never creates an implementation.
     return null
   }

--- a/client-base/src/main/kotlin/app/cash/backfila/client/spi/BackfilaClientServiceHandler.kt
+++ b/client-base/src/main/kotlin/app/cash/backfila/client/spi/BackfilaClientServiceHandler.kt
@@ -27,10 +27,10 @@ class BackfilaClientServiceHandler @Inject constructor(
 ) {
   @Throws(UnknownBackfillException::class)
   fun prepareBackfill(request: PrepareBackfillRequest): PrepareBackfillResponse {
-    return loggingSetupProvider.withBackfillRunLogging(request.backfill_name, request.backfill_id) {
-      logger.info { "Preparing backfill `${request.backfill_name}::${request.backfill_id}`" }
+    return loggingSetupProvider.withBackfillRunLogging(request.backfill_name, backfillId = null) {
+      logger.info { "Preparing backfill `${request.backfill_name}`" }
 
-      val operator = operatorFactory.create(request.backfill_name, request.backfill_id)
+      val operator = operatorFactory.create(request.backfill_name)
       return@withBackfillRunLogging operator.prepareBackfill(request)
     }
   }

--- a/client-base/src/main/kotlin/app/cash/backfila/client/spi/BackfillBackend.kt
+++ b/client-base/src/main/kotlin/app/cash/backfila/client/spi/BackfillBackend.kt
@@ -5,6 +5,6 @@ package app.cash.backfila.client.spi
  * that actually run the backfill.
  */
 interface BackfillBackend {
-  fun create(backfillName: String, backfillId: String): BackfillOperator?
+  fun create(backfillName: String): BackfillOperator?
   fun backfills(): Set<BackfillRegistration>
 }

--- a/client-base/src/test/kotlin/app/cash/backfila/client/fixedset/FixedSetBackend.kt
+++ b/client-base/src/test/kotlin/app/cash/backfila/client/fixedset/FixedSetBackend.kt
@@ -41,7 +41,7 @@ class FixedSetBackend @Inject constructor(
     parametersOperator = BackfilaParametersOperator(parametersClass(backfill::class)),
   )
 
-  override fun create(backfillName: String, backfillId: String): BackfillOperator? {
+  override fun create(backfillName: String): BackfillOperator? {
     val backfill = getBackfill(backfillName)
 
     if (backfill != null) {

--- a/client-dynamodb-v2/src/main/kotlin/app/cash/backfila/client/dynamodbv2/internal/DynamoDbBackend.kt
+++ b/client-dynamodb-v2/src/main/kotlin/app/cash/backfila/client/dynamodbv2/internal/DynamoDbBackend.kt
@@ -46,7 +46,7 @@ class DynamoDbBackend @Inject constructor(
     keyRangeCodec,
   )
 
-  override fun create(backfillName: String, backfillId: String): BackfillOperator? {
+  override fun create(backfillName: String): BackfillOperator? {
     val backfill = getBackfill(backfillName)
 
     if (backfill != null) {

--- a/client-dynamodb/src/main/kotlin/app/cash/backfila/client/dynamodb/internal/DynamoDbBackend.kt
+++ b/client-dynamodb/src/main/kotlin/app/cash/backfila/client/dynamodb/internal/DynamoDbBackend.kt
@@ -46,7 +46,7 @@ class DynamoDbBackend @Inject constructor(
     keyRangeCodec,
   )
 
-  override fun create(backfillName: String, backfillId: String): BackfillOperator? {
+  override fun create(backfillName: String): BackfillOperator? {
     val backfill = getBackfill(backfillName)
 
     if (backfill != null) {

--- a/client-jooq/src/main/kotlin/app/cash/backfila/client/jooq/internal/JooqBackend.kt
+++ b/client-jooq/src/main/kotlin/app/cash/backfila/client/jooq/internal/JooqBackend.kt
@@ -23,7 +23,7 @@ class JooqBackend @Inject constructor(
   @ForJooqBackend private val backfills: MutableMap<String, KClass<out JooqBackfill<*, *>>>,
 ) : BackfillBackend {
 
-  override fun create(backfillName: String, backfillId: String): JooqBackfillOperator<*, out Any>? {
+  override fun create(backfillName: String): JooqBackfillOperator<*, out Any>? {
     return getBackfill(backfillName)?.let {
       @Suppress("UNCHECKED_CAST")
       createJooqOperator(it as JooqBackfill<Any, Any>)

--- a/client-misk-hibernate/src/main/kotlin/app/cash/backfila/client/misk/hibernate/internal/HibernateBackend.kt
+++ b/client-misk-hibernate/src/main/kotlin/app/cash/backfila/client/misk/hibernate/internal/HibernateBackend.kt
@@ -43,7 +43,7 @@ internal class HibernateBackend @Inject constructor(
     this,
   )
 
-  override fun create(backfillName: String, backfillId: String): BackfillOperator? {
+  override fun create(backfillName: String): BackfillOperator? {
     val backfill = getBackfill(backfillName) ?: return null
 
     @Suppress("UNCHECKED_CAST") // We don't know the types statically, so fake them.

--- a/client-misk/src/main/kotlin/app/cash/backfila/client/misk/client/BackfilaClientMDCLoggingSetupProvider.kt
+++ b/client-misk/src/main/kotlin/app/cash/backfila/client/misk/client/BackfilaClientMDCLoggingSetupProvider.kt
@@ -8,10 +8,12 @@ import wisp.logging.getLogger
 class BackfilaClientMDCLoggingSetupProvider @Inject constructor() :
   BackfilaClientLoggingSetupProvider {
 
-  override fun <T> withBackfillRunLogging(backfillName: String, backfillId: String, wrapped: () -> T): T {
+  override fun <T> withBackfillRunLogging(backfillName: String, backfillId: String?, wrapped: () -> T): T {
     try {
       MDC.put(MDC_BACKFILL_NAME, backfillName)
-      MDC.put(MDC_BACKFILL_ID, backfillId)
+      backfillId?.let {
+        MDC.put(MDC_BACKFILL_ID, it)
+      }
     } catch (e: Exception) {
       logger.debug("Exception setting log context context", e)
     }

--- a/client-static/src/main/kotlin/app/cash/backfila/client/static/internal/StaticDatasourceBackend.kt
+++ b/client-static/src/main/kotlin/app/cash/backfila/client/static/internal/StaticDatasourceBackend.kt
@@ -41,7 +41,7 @@ class StaticDatasourceBackend @Inject constructor(
     BackfilaParametersOperator(parametersClass(backfill::class)),
   )
 
-  override fun create(backfillName: String, backfillId: String): BackfillOperator? {
+  override fun create(backfillName: String): BackfillOperator? {
     val backfill = getBackfill(backfillName)
 
     if (backfill != null) {

--- a/client/src/main/kotlin/app/cash/backfila/client/BackfilaClientLoggingSetupProvider.kt
+++ b/client/src/main/kotlin/app/cash/backfila/client/BackfilaClientLoggingSetupProvider.kt
@@ -3,13 +3,13 @@ package app.cash.backfila.client
 import javax.inject.Inject
 
 interface BackfilaClientLoggingSetupProvider {
-  fun <T> withBackfillRunLogging(backfillName: String, backfillId: String, wrapped: () -> T): T
+  fun <T> withBackfillRunLogging(backfillName: String, backfillId: String?, wrapped: () -> T): T
   fun <T> withBackfillPartitionLogging(backfillName: String, backfillId: String, partitionName: String, wrapped: () -> T): T
 }
 
 class BackfilaClientNoLoggingSetupProvider
 @Inject constructor() : BackfilaClientLoggingSetupProvider {
-  override fun <T> withBackfillRunLogging(backfillName: String, backfillId: String, wrapped: () -> T): T {
+  override fun <T> withBackfillRunLogging(backfillName: String, backfillId: String?, wrapped: () -> T): T {
     return wrapped.invoke()
   }
 

--- a/client/src/main/proto/app/cash/backfila/client_service.proto
+++ b/client/src/main/proto/app/cash/backfila/client_service.proto
@@ -15,9 +15,10 @@ message KeyRange {
 }
 
 message PrepareBackfillRequest {
-  // A unique identifier for this backfill run.
-  // Can be used as a caching key since backfill metadata is immutable after creation.
-  optional string backfill_id = 1;
+  // The id of the registered backfill.
+  // Deprecated and will be removed as it is confused with the backfill_id in later requests,
+  // which is only generated after preparing.
+  optional string backfill_id = 1 [deprecated = true];
 
   optional string backfill_name = 2;
 


### PR DESCRIPTION
We actually send the registered_backfill_id here, which is not what the docs say at all and misleading. We don't know the run id until Prepare gets a response. We should remove it