### PR TITLE
Updating metrics names because Prometheus requires it.

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/service/BackfilaMetrics.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/BackfilaMetrics.kt
@@ -7,73 +7,73 @@ import misk.metrics.Metrics
 @Singleton
 class BackfilaMetrics @Inject internal constructor(metrics: Metrics) {
   val runBatchDuration = metrics.histogram(
-    name = "run_batch_duration",
+    name = "run_batch_duration_ms",
     help = "duration of calls to runBatch in milliseconds",
     labelNames = perBackfillLabelNames,
   )
 
   val runBatchSuccesses = metrics.counter(
-    name = "run_batch_successes",
+    name = "run_batch_successes_total",
     help = "number of successful runBatch calls",
     labelNames = perBackfillLabelNames,
   )
 
   val runBatchFailures = metrics.counter(
-    name = "run_batch_failures",
+    name = "run_batch_failures_total",
     help = "number of failed runBatch calls",
     labelNames = perBackfillLabelNames,
   )
 
   val getNextBatchDuration = metrics.histogram(
-    name = "get_next_batch_duration",
+    name = "get_next_batch_duration_ms",
     help = "duration of calls to getNextBatch in milliseconds",
     labelNames = perBackfillLabelNames,
   )
 
   val getNextBatchSuccesses = metrics.counter(
-    name = "get_next_batch_successes",
+    name = "get_next_batch_successes_total",
     help = "number of successful getNextBatch calls",
     labelNames = perBackfillLabelNames,
   )
 
   val getNextBatchFailures = metrics.counter(
-    name = "get_next_batch_failures",
+    name = "get_next_batch_failures_total",
     help = "number of failed getNextBatch calls",
     labelNames = perBackfillLabelNames,
   )
 
   val computedBatchCount = metrics.counter(
-    name = "computed_batch_count",
+    name = "computed_batch_total",
     help = "number of batches computed",
     labelNames = perBackfillLabelNames,
   )
 
   val computedRecordsScanned = metrics.counter(
-    name = "compute_batch_records_scanned",
+    name = "compute_batch_records_scanned_total",
     help = "number of records computed (total scanned)",
     labelNames = perBackfillLabelNames,
   )
 
   val computedRecordsMatching = metrics.counter(
-    name = "compute_batch_records_matching",
+    name = "compute_batch_records_matching_total",
     help = "number of records computed (matching)",
     labelNames = perBackfillLabelNames,
   )
 
   val runBatchCompletedRecordsScanned = metrics.counter(
-    name = "run_batch_completed_records_scanned",
+    name = "run_batch_completed_records_scanned_total",
     help = "number of records completed (total scanned)",
     labelNames = perBackfillLabelNames,
   )
 
   val runBatchCompletedRecordsMatching = metrics.counter(
-    name = "run_batch_completed_records_matching",
+    name = "run_batch_completed_records_matching_total",
     help = "number of records completed (matching)",
     labelNames = perBackfillLabelNames,
   )
 
   val eta = metrics.gauge(
-    name = "backfill_eta",
+    name = "backfill_eta_ms",
     help = "Estimated remaining time for backfill completion in milliseconds based on the" +
       " records completed in the last minute",
     labelNames = perBackfillLabelNames,
@@ -87,7 +87,7 @@ class BackfilaMetrics @Inject internal constructor(metrics: Metrics) {
   )
 
   val blockedOnComputingNextBatchDuration = metrics.histogram(
-    name = "blocked_on_computing_next_batch_duration",
+    name = "blocked_on_computing_next_batch_duration_ms",
     help = "How long the BatchRunner was blocked waiting on the BatchQueuer to compute more batches to run." +
       " If this is greater than 0 there is probably a performance bottleneck in batch computing.",
     labelNames = perBackfillLabelNames,


### PR DESCRIPTION
Reason:
https://github.com/prometheus/client_java/releases/tag/parent-0.10.0

```
With this release the client_java simpleclient switches to the OpenMetrics data model and adds support for various new OpenMetrics-related features. This should be largely seamless, however any counters which lack a _total suffix on their sample will now have it added. If you'd prefer to make that change more gradually, you should change your metric names before upgrading to this version.
```