### PR TITLE
Upgrading to the v2 metrics

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/service/BackfilaMetrics.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/BackfilaMetrics.kt
@@ -2,7 +2,7 @@ package app.cash.backfila.service
 
 import javax.inject.Inject
 import javax.inject.Singleton
-import misk.metrics.Metrics
+import misk.metrics.v2.Metrics
 
 @Singleton
 class BackfilaMetrics @Inject internal constructor(metrics: Metrics) {

--- a/service/src/main/kotlin/app/cash/backfila/service/runner/BackfillRunner.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/runner/BackfillRunner.kt
@@ -247,10 +247,8 @@ class BackfillRunner private constructor(
         ),
       )
 
-      factory.metrics.runBatchDuration.record(
-        stopwatch.elapsed().toMillis().toDouble(),
-        *metricLabels,
-      )
+      factory.metrics.runBatchDuration.labels(*metricLabels)
+        .observe(stopwatch.elapsed().toMillis().toDouble())
       response
     }
   }

--- a/service/src/main/kotlin/app/cash/backfila/service/runner/statemachine/BatchQueuer.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/runner/statemachine/BatchQueuer.kt
@@ -94,18 +94,16 @@ class BatchQueuer(
 
         backfillRunner.factory.metrics.getNextBatchSuccesses
           .labels(*backfillRunner.metricLabels).inc()
-        backfillRunner.factory.metrics.getNextBatchDuration.record(
-          stopwatch.elapsed().toMillis().toDouble(),
-          *backfillRunner.metricLabels,
-        )
+        backfillRunner.factory.metrics.getNextBatchDuration.labels(*backfillRunner.metricLabels)
+          .observe(stopwatch.elapsed().toMillis().toDouble())
         backfillRunner.factory.metrics.computedBatchCount
           .labels(*backfillRunner.metricLabels).inc(response.batches.size.toDouble())
         backfillRunner.factory.metrics.computedRecordsMatching
           .labels(*backfillRunner.metricLabels)
-          .inc(response.batches.sumByDouble { it.matching_record_count.toDouble() })
+          .inc(response.batches.sumOf { it.matching_record_count.toDouble() })
         backfillRunner.factory.metrics.computedRecordsScanned
           .labels(*backfillRunner.metricLabels)
-          .inc(response.batches.sumByDouble { it.scanned_record_count.toDouble() })
+          .inc(response.batches.sumOf { it.scanned_record_count.toDouble() })
         backfillRunner.onRpcSuccess()
 
         if (response.batches.isEmpty()) {
@@ -125,10 +123,8 @@ class BatchQueuer(
         logger.info(e) { "Rpc failure when computing next batch for ${backfillRunner.logLabel()}" }
         backfillRunner.factory.metrics.getNextBatchFailures
           .labels(*backfillRunner.metricLabels).inc()
-        backfillRunner.factory.metrics.getNextBatchDuration.record(
-          stopwatch.elapsed().toMillis().toDouble(),
-          *backfillRunner.metricLabels,
-        )
+        backfillRunner.factory.metrics.getNextBatchDuration.labels(*backfillRunner.metricLabels)
+          .observe(stopwatch.elapsed().toMillis().toDouble())
         backfillRunner.onRpcFailure(e, "computing batch", stopwatch.elapsed())
       }
     }

--- a/service/src/main/kotlin/app/cash/backfila/service/runner/statemachine/BatchRunner.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/runner/statemachine/BatchRunner.kt
@@ -80,10 +80,9 @@ class BatchRunner(
         break
       }
 
-      backfillRunner.factory.metrics.blockedOnComputingNextBatchDuration.record(
-        stopwatch.elapsed().toMillis().toDouble(),
-        *backfillRunner.metricLabels,
-      )
+      backfillRunner.factory.metrics.blockedOnComputingNextBatchDuration
+        .labels(*backfillRunner.metricLabels)
+        .observe(stopwatch.elapsed().toMillis().toDouble())
       if (stopwatch.elapsed() > Duration.ofMillis(500)) {
         logger.info {
           "Runner stalled ${stopwatch.elapsed()} ms waiting for batch from " +


### PR DESCRIPTION
Mainly so we get true histograms:
https://github.com/cashapp/misk/blob/master/misk-metrics/src/main/kotlin/misk/metrics/v2/Metrics.kt
vs
https://github.com/cashapp/misk/blob/master/misk-metrics/src/main/kotlin/misk/metrics/Metrics.kt#L46