### PR TITLE
Prepare backfill: allow exposing an error message & stop sending backfill id

### DIFF
--- a/client/src/main/proto/app/cash/backfila/client_service.proto
+++ b/client/src/main/proto/app/cash/backfila/client_service.proto
@@ -45,6 +45,10 @@ message PrepareBackfillResponse {
   // Parameters created by the client to keep for the life of the backfill.
   // Every backfill call will pass these parameters back, in addition to user provided parameters.
   map<string, bytes> parameters = 2;
+
+  // Error message that will be surfaced to the user.
+  // If this is provided this prepare request is assumed to have failed and no backfill will be created.
+  optional string error_message = 3;
 }
 
 message GetNextBatchRangeRequest {

--- a/service/src/main/kotlin/app/cash/backfila/BackfillCreator.kt
+++ b/service/src/main/kotlin/app/cash/backfila/BackfillCreator.kt
@@ -110,20 +110,25 @@ class BackfillCreator @Inject constructor(
 
     val prepareBackfillResponse = try {
       client.prepareBackfill(
-        PrepareBackfillRequest(
-          dbData.registeredBackfillId.toString(),
-          request.backfill_name,
-          KeyRange(
-            request.pkey_range_start,
-            request.pkey_range_end,
-          ),
-          request.parameter_map,
-          dry_run,
-        ),
+        PrepareBackfillRequest.Builder()
+          .backfill_name(request.backfill_name)
+          .range(
+            KeyRange(
+              request.pkey_range_start,
+              request.pkey_range_end,
+            ),
+          )
+          .parameters(request.parameter_map)
+          .dry_run(dry_run)
+          .build(),
       )
     } catch (e: Exception) {
       logger.info(e) { "PrepareBackfill on `$service` failed" }
       throw BadRequestException("PrepareBackfill on `$service` failed: ${e.message}", e)
+    }
+
+    prepareBackfillResponse.error_message?.let {
+      throw BadRequestException("PrepareBackfill on `$service` failed: $it")
     }
 
     val partitions = prepareBackfillResponse.partitions

--- a/service/src/main/kotlin/app/cash/backfila/service/BackfilaDevelopmentService.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/BackfilaDevelopmentService.kt
@@ -61,17 +61,17 @@ fun main(args: Array<String>) {
             ): BackfilaClientServiceClient {
               return object : BackfilaClientServiceClient {
                 override fun prepareBackfill(request: PrepareBackfillRequest): PrepareBackfillResponse {
-                  return PrepareBackfillResponse(
-                    listOf(
-                      PrepareBackfillResponse.Partition(
-                        "-80", KeyRange("0".encodeUtf8(), "1000".encodeUtf8()), null,
+                  return PrepareBackfillResponse.Builder()
+                    .partitions(
+                      listOf(
+                        PrepareBackfillResponse.Partition(
+                          "-80", KeyRange("0".encodeUtf8(), "1000".encodeUtf8()), null,
+                        ),
+                        PrepareBackfillResponse.Partition(
+                          "80-", KeyRange("0".encodeUtf8(), "1000".encodeUtf8()), null,
+                        ),
                       ),
-                      PrepareBackfillResponse.Partition(
-                        "80-", KeyRange("0".encodeUtf8(), "1000".encodeUtf8()), null,
-                      ),
-                    ),
-                    mapOf(),
-                  )
+                    ).build()
                 }
 
                 override suspend fun getNextBatchRange(request: GetNextBatchRangeRequest): GetNextBatchRangeResponse {


### PR DESCRIPTION
This pr only handles it on the server. We need to deploy servers before setting this on the client since it will hide failures if we don't check the message.