### PR TITLE
Close S3 objects to release connection resources

### DIFF
--- a/client-s3/src/main/kotlin/app/cash/backfila/client/s3/internal/RealS3Service.kt
+++ b/client-s3/src/main/kotlin/app/cash/backfila/client/s3/internal/RealS3Service.kt
@@ -30,14 +30,18 @@ class RealS3Service @Inject constructor(
 
   override fun getFileStreamStartingAt(bucket: String, key: String, start: Long): BufferedSource {
     val s3Object = amazonS3.getObject(GetObjectRequest(bucket, key).withRange(start))
-    return s3Object.objectContent.source().buffer()
+    return s3Object.use {
+      it.objectContent.source().buffer()
+    }
   }
 
   override fun getWithSeek(bucket: String, key: String, seekStart: Long, seekEnd: Long): ByteString {
     val s3Object = amazonS3.getObject(GetObjectRequest(bucket, key).withRange(seekStart, seekEnd))
     return Buffer().run {
-      writeAll(s3Object.objectContent.source())
-      readByteString()
+      s3Object.use {
+        writeAll(it.objectContent.source())
+        readByteString()
+      }
     }
   }
 }


### PR DESCRIPTION
Im running into issues where the AWS HTTP threadpool is exhausted which results in connection timeouts. Im suspecting the open s3objects are the culprit.