### PR TITLE
Adding scan byte chunking strategies for GetNextBatchRange.

### DIFF
--- a/client-s3/src/main/kotlin/app/cash/backfila/client/s3/S3DatasourceBackfill.kt
+++ b/client-s3/src/main/kotlin/app/cash/backfila/client/s3/S3DatasourceBackfill.kt
@@ -4,6 +4,7 @@ import app.cash.backfila.client.Backfill
 import app.cash.backfila.client.BackfillConfig
 import app.cash.backfila.client.PrepareBackfillConfig
 import app.cash.backfila.client.s3.record.RecordStrategy
+import app.cash.backfila.client.s3.scan.DefaultAdaptiveScanByteStrategy
 
 abstract class S3DatasourceBackfill<R : Any, P : Any> : Backfill {
 
@@ -48,4 +49,10 @@ abstract class S3DatasourceBackfill<R : Any, P : Any> : Backfill {
    * Produces records from the S3 file.
    */
   abstract val recordStrategy: RecordStrategy<R>
+
+  /**
+   * The GetNextBatchRange scan chunk size strategy.
+   * initialByteLength defaults to 10MB.
+   */
+  open val scanByteStrategy = DefaultAdaptiveScanByteStrategy(initalByteLength = 10485760L)
 }

--- a/client-s3/src/main/kotlin/app/cash/backfila/client/s3/internal/RealS3Service.kt
+++ b/client-s3/src/main/kotlin/app/cash/backfila/client/s3/internal/RealS3Service.kt
@@ -28,13 +28,13 @@ class RealS3Service @Inject constructor(
     return objectMetadata.contentLength
   }
 
-  override fun getFileStreamStartingAt(bucket: String, key: String, start: Long): BufferedSource {
-    val s3Object = amazonS3.getObject(GetObjectRequest(bucket, key).withRange(start))
+  override fun getFileChunkSource(bucket: String, key: String, start: Long, end: Long): BufferedSource {
+    val s3Object = amazonS3.getObject(GetObjectRequest(bucket, key).withRange(start, end))
     return s3Object.objectContent.source().buffer()
   }
 
-  override fun getWithSeek(bucket: String, key: String, seekStart: Long, seekEnd: Long): ByteString {
-    val s3Object = amazonS3.getObject(GetObjectRequest(bucket, key).withRange(seekStart, seekEnd))
+  override fun getFileChunk(bucket: String, key: String, start: Long, end: Long): ByteString {
+    val s3Object = amazonS3.getObject(GetObjectRequest(bucket, key).withRange(start, end))
     return Buffer().run {
       s3Object.use {
         writeAll(it.objectContent.source())

--- a/client-s3/src/main/kotlin/app/cash/backfila/client/s3/scan/DefaultAdaptiveScanByteStrategy.kt
+++ b/client-s3/src/main/kotlin/app/cash/backfila/client/s3/scan/DefaultAdaptiveScanByteStrategy.kt
@@ -1,0 +1,33 @@
+package app.cash.backfila.client.s3.scan
+
+import app.cash.backfila.protos.clientservice.GetNextBatchRangeRequest
+import app.cash.backfila.protos.clientservice.GetNextBatchRangeResponse
+import com.google.common.base.Stopwatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * The default adaptive strategy that may change over time.
+ */
+class DefaultAdaptiveScanByteStrategy(initalByteLength: Long) : ScanByteStrategy {
+  private var bytesToScan = initalByteLength
+  override fun bytesToScan() = bytesToScan
+
+  override fun recordResult(
+    request: GetNextBatchRangeRequest,
+    batches: List<GetNextBatchRangeResponse.Batch>,
+    stopwatch: Stopwatch
+  ) {
+    // Estimate how many bytes it takes to come up with the correct number of batches.
+    val bytesPerBatch = batches.map { it.matching_record_count }.average().toLong()
+    val bytesPerScanByCount = bytesPerBatch * request.compute_count_limit
+
+    // Estimate the number of bytes we can process within our time limit.
+    val bytesProcessed = batches.map { it.matching_record_count }.sum()
+    // Think of ratio of duration as the number of these durations that could fit in our time limit.
+    val ratioOfDuration = request.compute_time_limit_ms / stopwatch.elapsed(TimeUnit.MILLISECONDS)
+    val bytesPerScanByTime = bytesProcessed * ratioOfDuration
+
+    // Set the result for next time
+    bytesToScan = bytesPerScanByCount.coerceAtMost(bytesPerScanByTime)
+  }
+}

--- a/client-s3/src/main/kotlin/app/cash/backfila/client/s3/scan/FixedScanByteStrategy.kt
+++ b/client-s3/src/main/kotlin/app/cash/backfila/client/s3/scan/FixedScanByteStrategy.kt
@@ -1,0 +1,21 @@
+package app.cash.backfila.client.s3.scan
+
+import app.cash.backfila.protos.clientservice.GetNextBatchRangeRequest
+import app.cash.backfila.protos.clientservice.GetNextBatchRangeResponse
+import com.google.common.base.Stopwatch
+
+/**
+ * Use this if all you want is always read a certain number of bytes. Use this if the adaptive
+ * strategy isn't working for you.
+ */
+class FixedScanByteStrategy(private val fixedByteLength: Long) : ScanByteStrategy {
+  override fun bytesToScan() = fixedByteLength
+
+  override fun recordResult(
+    request: GetNextBatchRangeRequest,
+    batches: List<GetNextBatchRangeResponse.Batch>,
+    stopwatch: Stopwatch
+  ) {
+    // Do nothing.
+  }
+}

--- a/client-s3/src/main/kotlin/app/cash/backfila/client/s3/scan/ScanByteStrategy.kt
+++ b/client-s3/src/main/kotlin/app/cash/backfila/client/s3/scan/ScanByteStrategy.kt
@@ -1,0 +1,26 @@
+package app.cash.backfila.client.s3.scan
+
+import app.cash.backfila.protos.clientservice.GetNextBatchRangeRequest
+import app.cash.backfila.protos.clientservice.GetNextBatchRangeResponse
+import com.google.common.base.Stopwatch
+
+/**
+ * S3 requires that a file can only be partially read by reading chunks. The semantics of an
+ * open-ended read is that you read the rest of the file. This strategy gives you a way to influence
+ * how much data you request for each GetNextBatchRange scan request.
+ *
+ * NOTE: This can contain state for a backfill instance so each backfill should create a copy.
+ */
+interface ScanByteStrategy {
+
+  fun bytesToScan(): Long
+
+  /**
+   * Gives feedback to the strategy on what was accomplished in this GetNextBatchRange scan.
+   */
+  fun recordResult(
+    request: GetNextBatchRangeRequest,
+    batches: List<GetNextBatchRangeResponse.Batch>,
+    stopwatch: Stopwatch
+  )
+}

--- a/client-s3/src/main/kotlin/app/cash/backfila/client/s3/shim/FakeS3Service.kt
+++ b/client-s3/src/main/kotlin/app/cash/backfila/client/s3/shim/FakeS3Service.kt
@@ -44,18 +44,18 @@ class FakeS3Service @Inject constructor() : S3Service {
     .filter { (fileBucket, key) -> fileBucket == bucket && key.startsWith(keyPrefix) }
     .map { it.second }
 
-  override fun getFileStreamStartingAt(bucket: String, key: String, start: Long): BufferedSource {
-    val remainder = files[bucket to key]?.substring(start.toInt()) ?: EMPTY
-    assert(remainder.size != 0) { "Amazon throws 'The requested range is not satisfiable'" }
-    return Buffer().write(remainder)
+  override fun getFileChunkSource(bucket: String, key: String, start: Long, end: Long): BufferedSource {
+    val chunk = files[bucket to key]?.substring(start.toInt(), end.toInt()) ?: EMPTY
+    assert(chunk.size != 0) { "Amazon throws 'The requested range is not satisfiable'" }
+    return Buffer().write(chunk)
   }
 
-  override fun getWithSeek(
+  override fun getFileChunk(
     bucket: String,
     key: String,
-    seekStart: Long,
-    seekEnd: Long,
-  ): ByteString = files[bucket to key]?.substring(seekStart.toInt(), seekEnd.toInt()) ?: EMPTY
+    start: Long,
+    end: Long,
+  ): ByteString = files[bucket to key]?.substring(start.toInt(), end.toInt()) ?: EMPTY
 
   override fun getFileSize(bucket: String, key: String): Long =
     files[bucket to key]?.size?.toLong() ?: 0L

--- a/client-s3/src/main/kotlin/app/cash/backfila/client/s3/shim/S3Service.kt
+++ b/client-s3/src/main/kotlin/app/cash/backfila/client/s3/shim/S3Service.kt
@@ -10,16 +10,19 @@ interface S3Service {
   fun listFiles(bucket: String, pathPrefix: String): List<String>
 
   /**
-   * Starts a streaming the file starting at a certain byte.
-   * start is in bytes.
+   * Starts a streaming the file starting at a certain byte and until a certain byte. This can more
+   * readily stream large portions of the file.
+   *
+   * start and end are in bytes.
    */
-  fun getFileStreamStartingAt(bucket: String, key: String, start: Long): BufferedSource
+  fun getFileChunkSource(bucket: String, key: String, start: Long, end: Long): BufferedSource
 
   /**
-   * Obtains a file slice.
-   * seekStart and seekEnd are in bytes.
+   * Obtains a file chunk ByteString. Use this for chunks that are not too long.
+   *
+   * start and end are in bytes.
    */
-  fun getWithSeek(bucket: String, key: String, seekStart: Long, seekEnd: Long): ByteString
+  fun getFileChunk(bucket: String, key: String, seekStart: Long, seekEnd: Long): ByteString
 
   /**
    * Returns the size in bytes.


### PR DESCRIPTION
I had the semantics wrong. Not putting in an end assumes you want the whole file. So I'm adding an adaptive strategy to find the chunk size.
https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/GetObjectRequest.html#setRange-long-

I will add some tests before merging but sending this out as it is for comment.