### PR TITLE
Allow passing expressionAttributeNames to ScanRequest for DynamoDB backfills

### DIFF
--- a/client-dynamodb-v2/src/main/kotlin/app/cash/backfila/client/dynamodbv2/DynamoDbBackfill.kt
+++ b/client-dynamodb-v2/src/main/kotlin/app/cash/backfila/client/dynamodbv2/DynamoDbBackfill.kt
@@ -84,4 +84,7 @@ abstract class DynamoDbBackfill<I : Any, P : Any> : Backfill {
 
   /** See [ScanRequest.setExpressionAttributeValues]. */
   open fun expressionAttributeValues(config: BackfillConfig<P>): Map<String, AttributeValue>? = null
+
+  /** See [ScanRequest.setExpressionAttributeNames]. */
+  open fun expressionAttributeNames(config: BackfillConfig<P>): Map<String, String>? = null
 }

--- a/client-dynamodb-v2/src/main/kotlin/app/cash/backfila/client/dynamodbv2/internal/DynamoDbBackfillOperator.kt
+++ b/client-dynamodb-v2/src/main/kotlin/app/cash/backfila/client/dynamodbv2/internal/DynamoDbBackfillOperator.kt
@@ -132,6 +132,7 @@ class DynamoDbBackfillOperator<I : Any, P : Any>(
         }
         .filterExpression(backfill.filterExpression(config))
         .expressionAttributeValues(backfill.expressionAttributeValues(config))
+        .expressionAttributeNames(backfill.expressionAttributeNames(config))
         .build()
 
       val result = dynamoDbClient.scan(scanRequest)

--- a/client-dynamodb-v2/src/test/kotlin/app/cash/backfila/client/dynamodbv2/BackfillsModule.kt
+++ b/client-dynamodb-v2/src/test/kotlin/app/cash/backfila/client/dynamodbv2/BackfillsModule.kt
@@ -23,6 +23,7 @@ class BackfillsModule : KAbstractModule() {
     install(DynamoDbBackfillModule.create<DynamoDbBackfillTest.MakeTracksExplicitBackfill>())
     install(DynamoDbBackfillModule.create<DynamoDbFilteringTest.FilteredMakeTracksExplicitBackfill>())
     install(DynamoDbBackfillModule.create<DynamoDbFilteringTest.DynamoFilterMakeTracksExplicitBackfill>())
+    install(DynamoDbBackfillModule.create<DynamoDbFilteringTest.DynamoFilterWithAttributeNameMakeTracksExplicitBackfill>())
     install(DynamoDbBackfillModule.create<DynamoDbSegmentingTest.SegmentingBackfill>())
     install(DynamoDbBackfillModule.create<DynamoDbLastEvaluatedKeyTest.PausingBackfill>())
     install(DynamoDbBackfillModule.create<DynamoDbBillingModeTest.EmptyTrackBackfill>())

--- a/client-dynamodb/src/main/kotlin/app/cash/backfila/client/dynamodb/DynamoDbBackfill.kt
+++ b/client-dynamodb/src/main/kotlin/app/cash/backfila/client/dynamodb/DynamoDbBackfill.kt
@@ -73,4 +73,7 @@ abstract class DynamoDbBackfill<I : Any, P : Any> : Backfill {
 
   /** See [ScanRequest.setExpressionAttributeValues]. */
   open fun expressionAttributeValues(config: BackfillConfig<P>): Map<String, AttributeValue>? = null
+
+  /** See [ScanRequest.setExpressionAttributeNames]. */
+  open fun expressionAttributeNames(config: BackfillConfig<P>): Map<String, String>? = null
 }

--- a/client-dynamodb/src/main/kotlin/app/cash/backfila/client/dynamodb/internal/DynamoDbBackfillOperator.kt
+++ b/client-dynamodb/src/main/kotlin/app/cash/backfila/client/dynamodb/internal/DynamoDbBackfillOperator.kt
@@ -118,6 +118,7 @@ class DynamoDbBackfillOperator<I : Any, P : Any>(
         }
         this.filterExpression = backfill.filterExpression(config)
         this.expressionAttributeValues = backfill.expressionAttributeValues(config)
+        this.expressionAttributeNames = backfill.expressionAttributeNames(config)
       }
       val result = dynamoDb.scanPage(backfill.itemType.java, scanRequest)
       backfill.runBatch(result.results, config)

--- a/client-dynamodb/src/test/kotlin/app/cash/backfila/client/dynamodb/BackfillsModule.kt
+++ b/client-dynamodb/src/test/kotlin/app/cash/backfila/client/dynamodb/BackfillsModule.kt
@@ -23,6 +23,7 @@ class BackfillsModule : KAbstractModule() {
     install(DynamoDbBackfillModule.create<DynamoDbBackfillTest.MakeTracksExplicitBackfill>())
     install(DynamoDbBackfillModule.create<DynamoDbFilteringTest.FilteredMakeTracksExplicitBackfill>())
     install(DynamoDbBackfillModule.create<DynamoDbFilteringTest.DynamoFilterMakeTracksExplicitBackfill>())
+    install(DynamoDbBackfillModule.create<DynamoDbFilteringTest.DynamoFilterWithAttributeNameMakeTracksExplicitBackfill>())
     install(DynamoDbBackfillModule.create<DynamoDbSegmentingTest.SegmentingBackfill>())
     install(DynamoDbBackfillModule.create<DynamoDbLastEvaluatedKeyTest.PausingBackfill>())
     install(DynamoDbBackfillModule.create<DynamoDbBillingModeTest.EmptyTrackBackfill>())


### PR DESCRIPTION
Backfila currently doesn't expose setting expressionAttributeNames on the scan request as part of the DynamoDBBackfills. This PR adds that functionality to support the use cases mentioned [here](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html) when utilizing filter expressions. 