### PR TITLE
Adds dynamodb sdk v1 backfill on index

### DIFF
--- a/client-dynamodb/build.gradle.kts
+++ b/client-dynamodb/build.gradle.kts
@@ -52,6 +52,11 @@ dependencies {
       strictly("4.9.3")
     }
   }
+
+  // Required for M1 macs
+  if (org.apache.tools.ant.taskdefs.condition.Os.isArch("aarch64")) {
+    testImplementation("io.github.ganadist.sqlite4java:libsqlite4java-osx-aarch64:1.0.392")
+  }
 }
 
 configure<MavenPublishBaseExtension> {

--- a/client-dynamodb/build.gradle.kts
+++ b/client-dynamodb/build.gradle.kts
@@ -52,11 +52,6 @@ dependencies {
       strictly("4.9.3")
     }
   }
-
-  // Required for M1 macs
-  if (org.apache.tools.ant.taskdefs.condition.Os.isArch("aarch64")) {
-    testImplementation("io.github.ganadist.sqlite4java:libsqlite4java-osx-aarch64:1.0.392")
-  }
 }
 
 configure<MavenPublishBaseExtension> {

--- a/client-dynamodb/src/main/kotlin/app/cash/backfila/client/dynamodb/DynamoDbBackfill.kt
+++ b/client-dynamodb/src/main/kotlin/app/cash/backfila/client/dynamodb/DynamoDbBackfill.kt
@@ -76,4 +76,7 @@ abstract class DynamoDbBackfill<I : Any, P : Any> : Backfill {
 
   /** See [ScanRequest.setExpressionAttributeNames]. */
   open fun expressionAttributeNames(config: BackfillConfig<P>): Map<String, String>? = null
+
+  /** See [ScanRequest.setIndexName]. */
+  open fun indexName(config: BackfillConfig<P>): String? = null
 }

--- a/client-dynamodb/src/main/kotlin/app/cash/backfila/client/dynamodb/internal/DynamoDbBackfillOperator.kt
+++ b/client-dynamodb/src/main/kotlin/app/cash/backfila/client/dynamodb/internal/DynamoDbBackfillOperator.kt
@@ -119,6 +119,7 @@ class DynamoDbBackfillOperator<I : Any, P : Any>(
         this.filterExpression = backfill.filterExpression(config)
         this.expressionAttributeValues = backfill.expressionAttributeValues(config)
         this.expressionAttributeNames = backfill.expressionAttributeNames(config)
+        this.indexName = backfill.indexName(config)
       }
       val result = dynamoDb.scanPage(backfill.itemType.java, scanRequest)
       backfill.runBatch(result.results, config)

--- a/client-dynamodb/src/test/kotlin/app/cash/backfila/client/dynamodb/BackfillsModule.kt
+++ b/client-dynamodb/src/test/kotlin/app/cash/backfila/client/dynamodb/BackfillsModule.kt
@@ -28,5 +28,6 @@ class BackfillsModule : KAbstractModule() {
     install(DynamoDbBackfillModule.create<DynamoDbLastEvaluatedKeyTest.PausingBackfill>())
     install(DynamoDbBackfillModule.create<DynamoDbBillingModeTest.EmptyTrackBackfill>())
     install(DynamoDbBackfillModule.create<DynamoDbBillingModeTest.ReallyExpensiveBackfill>())
+    install(DynamoDbBackfillModule.create<DynamoDbIndexTest.MakeTracksExplicitBackfill>())
   }
 }

--- a/client-dynamodb/src/test/kotlin/app/cash/backfila/client/dynamodb/BackfillsModule.kt
+++ b/client-dynamodb/src/test/kotlin/app/cash/backfila/client/dynamodb/BackfillsModule.kt
@@ -28,6 +28,6 @@ class BackfillsModule : KAbstractModule() {
     install(DynamoDbBackfillModule.create<DynamoDbLastEvaluatedKeyTest.PausingBackfill>())
     install(DynamoDbBackfillModule.create<DynamoDbBillingModeTest.EmptyTrackBackfill>())
     install(DynamoDbBackfillModule.create<DynamoDbBillingModeTest.ReallyExpensiveBackfill>())
-    install(DynamoDbBackfillModule.create<DynamoDbIndexTest.MakeTracksExplicitBackfill>())
+    install(DynamoDbBackfillModule.create<DynamoDbIndexTest.MakeTracksAsSinglesBackfill>())
   }
 }

--- a/client-dynamodb/src/test/kotlin/app/cash/backfila/client/dynamodb/DynamoDbIndexTest.kt
+++ b/client-dynamodb/src/test/kotlin/app/cash/backfila/client/dynamodb/DynamoDbIndexTest.kt
@@ -69,7 +69,7 @@ class DynamoDbIndexTest {
 
     override fun runOne(item: TrackItem, config: BackfillConfig<SingleParameters>): Boolean {
       val trackTitle = item.track_title ?: return false
-      if (trackTitle.endsWith(" (Single)")) return false // Idempotent retry?
+      if (trackTitle.endsWith(" (Single)")) return true
       item.track_title = "$trackTitle (Single)"
       return true
     }

--- a/client-dynamodb/src/test/kotlin/app/cash/backfila/client/dynamodb/DynamoDbIndexTest.kt
+++ b/client-dynamodb/src/test/kotlin/app/cash/backfila/client/dynamodb/DynamoDbIndexTest.kt
@@ -1,0 +1,81 @@
+package app.cash.backfila.client.dynamodb
+
+import app.cash.backfila.client.BackfillConfig
+import app.cash.backfila.client.misk.TestingModule
+import app.cash.backfila.embedded.Backfila
+import app.cash.backfila.embedded.createWetRun
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression
+import javax.inject.Inject
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@MiskTest(startService = true)
+class DynamoDbIndexTest {
+  @Suppress("unused")
+  @MiskTestModule
+  val module = TestingModule()
+
+  @Inject lateinit var dynamoDb: DynamoDBMapper
+
+  @Inject lateinit var backfila: Backfila
+
+  @Inject lateinit var testData: DynamoMusicTableTestData
+
+  @Test
+  fun `only items in the specified index are processed`() {
+    val trackItem = TrackItem().apply {
+      this.album_token = "ALBUM_2"
+      this.sort_key = "TRACK_03"
+      this.track_title = "Thriller"
+      this.album_title = "MJ"
+    }
+    dynamoDb.save(trackItem)
+
+    val trackItem2 = TrackItem().apply {
+      this.album_token = "ALBUM_3"
+      this.sort_key = "TRACK_01"
+      this.track_title = "Anon"
+      // No album title so its excluded from the trackTitleIndex sparse GSI.
+    }
+    dynamoDb.save(trackItem2)
+
+    assertThat(rowsInIndex().size).isEqualTo(1)
+    assertThat(testData.getRowsDump().size).isEqualTo(2)
+
+    val run = backfila.createWetRun<MakeTracksExplicitBackfill>()
+    run.execute()
+
+    // Only rows from the index were updated.
+    assertThat(dynamoDb.load(TrackItem::class.java, "ALBUM_2", "TRACK_03").track_title)
+      .isEqualTo("Thriller (EXPLICIT)")
+    assertThat(dynamoDb.load(TrackItem::class.java, "ALBUM_3", "TRACK_01").track_title)
+      .isEqualTo("Anon")
+  }
+
+  private fun rowsInIndex(): List<TrackItem> {
+    val scanRequest = DynamoDBScanExpression().apply {
+      limit = 10000
+      indexName = "trackTitleIndex"
+    }
+    return dynamoDb.scan(TrackItem::class.java, scanRequest)
+  }
+
+  class MakeTracksExplicitBackfill @Inject constructor(
+    dynamoDb: DynamoDBMapper,
+  ) : UpdateInPlaceDynamoDbBackfill<TrackItem, MakeTracksExplicitBackfill.ExplicitParameters>(dynamoDb) {
+
+    override fun runOne(item: TrackItem, config: BackfillConfig<ExplicitParameters>): Boolean {
+      val trackTitle = item.track_title ?: return false
+      if (trackTitle.endsWith(" (EXPLICIT)")) return false // Idempotent retry?
+      item.track_title = "$trackTitle (EXPLICIT)"
+      return true
+    }
+
+    data class ExplicitParameters(val validate: Boolean = true)
+
+    override fun indexName(config: BackfillConfig<ExplicitParameters>): String? = "trackTitleIndex"
+  }
+}

--- a/client-dynamodb/src/test/kotlin/app/cash/backfila/client/dynamodb/TrackItem.kt
+++ b/client-dynamodb/src/test/kotlin/app/cash/backfila/client/dynamodb/TrackItem.kt
@@ -2,6 +2,8 @@ package app.cash.backfila.client.dynamodb
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexRangeKey
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable
 
@@ -14,9 +16,11 @@ class TrackItem {
   @DynamoDBRangeKey
   var sort_key: String? = null
 
+  @DynamoDBIndexHashKey(globalSecondaryIndexName = "trackTitleIndex", attributeName = "track_title")
   @DynamoDBAttribute
   var track_title: String? = null
 
+  @DynamoDBIndexRangeKey(globalSecondaryIndexName = "trackTitleIndex", attributeName = "album_title")
   @DynamoDBAttribute
   var album_title: String? = null
 


### PR DESCRIPTION
Allows the backfill to specify an indexName to be used in the scan rather than the main table.