### PR TITLE
Add JVM overloads for the constructors

### DIFF
--- a/client/src/main/kotlin/app/cash/backfila/client/Connectors.kt
+++ b/client/src/main/kotlin/app/cash/backfila/client/Connectors.kt
@@ -7,6 +7,6 @@ object Connectors {
 
 data class HttpHeader(val name: String, val value: String)
 
-data class HttpConnectorData(val url: String, val headers: List<HttpHeader> = listOf())
+data class HttpConnectorData @JvmOverloads constructor(val url: String, val headers: List<HttpHeader> = listOf())
 
-data class EnvoyConnectorData(val clusterType: String, val headers: List<HttpHeader> = listOf())
+data class EnvoyConnectorData @JvmOverloads constructor(val clusterType: String, val headers: List<HttpHeader> = listOf())


### PR DESCRIPTION
This fixes the API incompatibility introduced by
https://github.com/cashapp/backfila/pull/331