### PR TITLE
Have embedded backfila keep track of runs.

### DIFF
--- a/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/Backfila.kt
+++ b/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/Backfila.kt
@@ -26,6 +26,11 @@ interface Backfila {
     rangeEnd: String?,
   ): BackfillRun<Type>
 
+  fun <Type : Backfill> findExistingRun(
+    backfillType: KClass<Type>,
+    backfillRunId: Long,
+  ): BackfillRun<Type>
+
   val configureServiceData: ConfigureServiceRequest?
 }
 

--- a/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/BackfillRun.kt
+++ b/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/BackfillRun.kt
@@ -16,7 +16,7 @@ interface BackfillRun<B : Backfill> {
   val parameters: Map<String, ByteString>
   val rangeStart: String?
   val rangeEnd: String?
-  val backfillId: String
+  val backfillRunId: String
 
   var batchSize: Long
   var scanSize: Long

--- a/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/internal/EmbeddedBackfillRun.kt
+++ b/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/internal/EmbeddedBackfillRun.kt
@@ -26,7 +26,7 @@ internal class EmbeddedBackfillRun<B : Backfill>(
   override val parameters: MutableMap<String, ByteString>,
   override val rangeStart: String?,
   override val rangeEnd: String?,
-  override val backfillId: String,
+  override val backfillRunId: String,
 
   override var batchSize: Long = 100L,
   override var scanSize: Long = 10_000L,
@@ -76,7 +76,7 @@ internal class EmbeddedBackfillRun<B : Backfill>(
     val response =
       operator.getNextBatchRange(
         GetNextBatchRangeRequest.Builder()
-          .backfill_id(backfillId)
+          .backfill_id(backfillRunId)
           .partition_name(cursor.partitionName)
           .backfill_range(cursor.keyRange)
           .previous_end_key(cursor.previousEndKey)
@@ -115,7 +115,7 @@ internal class EmbeddedBackfillRun<B : Backfill>(
     val response =
       operator.getNextBatchRange(
         GetNextBatchRangeRequest.Builder()
-          .backfill_id(backfillId)
+          .backfill_id(backfillRunId)
           .partition_name(cursor.partitionName)
           .backfill_range(cursor.keyRange)
           .previous_end_key(cursor.previousEndKey)
@@ -167,7 +167,7 @@ internal class EmbeddedBackfillRun<B : Backfill>(
       val remainingBatch = batch.copy(batchRange = remainingRange)
       response = operator.runBatch(
         RunBatchRequest.Builder()
-          .backfill_id(backfillId)
+          .backfill_id(backfillRunId)
           .partition_name(remainingBatch.partitionName)
           .batch_range(remainingBatch.batchRange)
           .parameters(parameters)

--- a/client-base/src/test/kotlin/app/cash/backfila/client/BackfilaApiTest.kt
+++ b/client-base/src/test/kotlin/app/cash/backfila/client/BackfilaApiTest.kt
@@ -1,0 +1,96 @@
+package app.cash.backfila.client
+
+import app.cash.backfila.client.fixedset.FixedSetDatastore
+import app.cash.backfila.embedded.Backfila
+import app.cash.backfila.embedded.createWetRun
+import app.cash.backfila.protos.service.CheckBackfillStatusRequest
+import app.cash.backfila.protos.service.CheckBackfillStatusResponse.Status.COMPLETE
+import app.cash.backfila.protos.service.CheckBackfillStatusResponse.Status.RUNNING
+import app.cash.backfila.protos.service.CreateAndStartBackfillRequest
+import app.cash.backfila.protos.service.CreateBackfillRequest
+import com.google.inject.Module
+import javax.inject.Inject
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.SoftAssertions
+import org.junit.jupiter.api.Test
+
+@MiskTest(startService = true)
+class BackfilaApiTest {
+  @Suppress("unused")
+  @MiskTestModule
+  val module: Module = TestingModule()
+
+  @Inject lateinit var backfila: Backfila
+
+  @Inject lateinit var backfilaApi: BackfilaApi
+
+  @Inject lateinit var datastore: FixedSetDatastore
+
+  @Test fun `createAndStartBackfill happy path`() {
+    datastore.put("instance", "a", "b", "c")
+
+    val createResponse = backfilaApi.createAndStartbackfill(
+      CreateAndStartBackfillRequest(
+        CreateBackfillRequest.Builder()
+          .backfill_name(ToUpperCaseBackfill::class.java.name)
+          .dry_run(false) // wet run
+          .build(),
+      ),
+    ).execute()
+    val backfillRunId = createResponse.body()!!.backfill_run_id
+    val backfillRun = backfila.findExistingRun(ToUpperCaseBackfill::class, backfillRunId)
+    // Check that the backfill worked.
+    assertThat(backfillRun.backfill.runOrder).containsExactly("a", "b", "c")
+    assertThat(datastore.valuesToList()).containsExactly("A", "B", "C")
+    val statusResponse = backfilaApi.checkBackfillStatus(CheckBackfillStatusRequest(backfillRunId)).execute().body()!!
+    assertThat(statusResponse.status).isEqualTo(COMPLETE)
+  }
+
+  @Test fun `find started backfill`() {
+    datastore.put("instance", "a", "b", "c")
+
+    val backfillRun = backfila.createWetRun<ToUpperCaseBackfill>()
+    // Check that the backfill hasn't started.
+    assertThat(backfillRun.backfill.runOrder).isEmpty()
+    val runningResponse = backfilaApi.checkBackfillStatus(CheckBackfillStatusRequest(backfillRun.backfillRunId.toLong())).execute().body()!!
+    assertThat(runningResponse.status).isEqualTo(RUNNING)
+
+    // Now finish the backfill
+    backfillRun.execute()
+    assertThat(backfillRun.backfill.runOrder).isNotEmpty()
+    val completeResponse = backfilaApi.checkBackfillStatus(CheckBackfillStatusRequest(backfillRun.backfillRunId.toLong())).execute().body()!!
+    assertThat(completeResponse.status).isEqualTo(COMPLETE)
+  }
+
+  @Test fun `test edge cases`() {
+    datastore.put("instance", "a", "b", "c")
+
+    val createResponse = backfilaApi.createAndStartbackfill(
+      CreateAndStartBackfillRequest(
+        CreateBackfillRequest.Builder()
+          .backfill_name(ToUpperCaseBackfill::class.java.name)
+          .dry_run(false) // wet run
+          .build(),
+      ),
+    ).execute()
+    val backfillRunId = createResponse.body()!!.backfill_run_id
+
+    with(SoftAssertions()) {
+      assertThatCode {
+        backfila.findExistingRun(ToUpperCaseBackfill::class, backfillRunId + 1)
+      }.hasMessageContaining("No Backfill with id ${backfillRunId + 1} found")
+
+      assertThatCode {
+        backfila.findExistingRun(ToLowerCaseBackfill::class, backfillRunId)
+      }.hasMessageContaining("Backfill with run id $backfillRunId is not of type class ${ToLowerCaseBackfill::class.qualifiedName}")
+
+      assertThatCode {
+        backfilaApi.checkBackfillStatus(CheckBackfillStatusRequest(backfillRunId + 1)).execute()
+      }.hasMessageContaining("No Backfill with id ${backfillRunId + 1} found")
+
+      assertAll()
+    }
+  }
+}

--- a/client-base/src/test/kotlin/app/cash/backfila/client/BackfillsModule.kt
+++ b/client-base/src/test/kotlin/app/cash/backfila/client/BackfillsModule.kt
@@ -13,7 +13,8 @@ class BackfillsModule : KAbstractModule() {
         ),
       ),
     )
-    install(FixedSetBackfillModule.create<FixedSetTest.ToUpperCaseBackfill>())
+    install(FixedSetBackfillModule.create<ToUpperCaseBackfill>())
+    install(FixedSetBackfillModule.create<ToLowerCaseBackfill>())
     install(FixedSetBackfillModule.create<DeleteBackfillByTest.TenYearBackfill>())
     install(FixedSetBackfillModule.create<DeleteBackfillByTest.DeprecatedBackfill>())
     install(FixedSetBackfillModule.create<PrepareWithParametersTest.PrepareWithParametersBackfill>())

--- a/client-base/src/test/kotlin/app/cash/backfila/client/CaseBackfills.kt
+++ b/client-base/src/test/kotlin/app/cash/backfila/client/CaseBackfills.kt
@@ -1,0 +1,29 @@
+package app.cash.backfila.client
+
+import app.cash.backfila.client.fixedset.FixedSetBackfill
+import app.cash.backfila.client.fixedset.FixedSetRow
+import java.util.Locale
+import javax.inject.Inject
+
+/**
+ * Simple backfills to be used in tests.
+ */
+class ToUpperCaseBackfill @Inject constructor() : FixedSetBackfill<NoParameters>() {
+  val runOrder = mutableListOf<String>()
+  var seenBackfillId: String? = null
+  override fun runOne(row: FixedSetRow, backfillConfig: BackfillConfig<NoParameters>) {
+    seenBackfillId = backfillConfig.backfillId
+    runOrder += row.value
+    row.value = row.value.uppercase(Locale.ROOT)
+  }
+}
+
+class ToLowerCaseBackfill @Inject constructor() : FixedSetBackfill<NoParameters>() {
+  val runOrder = mutableListOf<String>()
+  var seenBackfillId: String? = null
+  override fun runOne(row: FixedSetRow, backfillConfig: BackfillConfig<NoParameters>) {
+    seenBackfillId = backfillConfig.backfillId
+    runOrder += row.value
+    row.value = row.value.lowercase(Locale.ROOT)
+  }
+}

--- a/client-base/src/test/kotlin/app/cash/backfila/client/FixedSetTest.kt
+++ b/client-base/src/test/kotlin/app/cash/backfila/client/FixedSetTest.kt
@@ -1,12 +1,9 @@
 package app.cash.backfila.client
 
-import app.cash.backfila.client.fixedset.FixedSetBackfill
 import app.cash.backfila.client.fixedset.FixedSetDatastore
-import app.cash.backfila.client.fixedset.FixedSetRow
 import app.cash.backfila.embedded.Backfila
 import app.cash.backfila.embedded.createWetRun
 import com.google.inject.Module
-import java.util.Locale
 import javax.inject.Inject
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -22,16 +19,6 @@ class FixedSetTest {
   @Inject lateinit var backfila: Backfila
 
   @Inject lateinit var datastore: FixedSetDatastore
-
-  class ToUpperCaseBackfill @Inject constructor() : FixedSetBackfill<NoParameters>() {
-    val runOrder = mutableListOf<String>()
-    var seenBackfillId: String? = null
-    override fun runOne(row: FixedSetRow, backfillConfig: BackfillConfig<NoParameters>) {
-      seenBackfillId = backfillConfig.backfillId
-      runOrder += row.value
-      row.value = row.value.toUpperCase(Locale.ROOT)
-    }
-  }
 
   @Test fun `happy path`() {
     datastore.put("instance", "a", "b", "c")


### PR DESCRIPTION
Now clients that use createAndStartBackfill can use the EmbeddedBackfila for tests.