### PR TITLE
Allow service list to be filtered by one that have running backfills

### DIFF
--- a/service/web/tabs/app/src/components/ServicesListComponent.tsx
+++ b/service/web/tabs/app/src/components/ServicesListComponent.tsx
@@ -7,10 +7,13 @@ export interface ITableProps {
   data: any
   url?: string
   tag?: string
+  onlyShowRunningBackfills: boolean
 }
 
 export const ServicesListComponent = (props: ITableProps) => {
   const { data } = props
+  const serviceHasRunningBackfills = (service: any) => service.running_backfills > 0
+  const shouldShowService = (service: any) => !props.onlyShowRunningBackfills || serviceHasRunningBackfills(service)
   if (data) {
     /**
      * Data is loaded and ready to be rendered
@@ -20,7 +23,9 @@ export const ServicesListComponent = (props: ITableProps) => {
         <H1>Services</H1>
         <HTMLTable bordered={true} striped={true}>
           <tbody>
-            {data.map((service: any) => (
+            {data
+              .filter(shouldShowService)
+              .map((service: any) => (
               <tr>
                 <td>
                   <ServiceLink

--- a/service/web/tabs/app/src/containers/HomeContainer.tsx
+++ b/service/web/tabs/app/src/containers/HomeContainer.tsx
@@ -8,30 +8,55 @@ import {
   mapDispatchToProps,
   mapStateToProps
 } from "src/ducks"
+import {Checkbox, FormGroup} from "@blueprintjs/core"
 import { LayoutContainer } from "."
+import { RouteComponentProps } from 'react-router-dom';
 
-class TabContainer extends React.Component<IState & IDispatchProps, IState> {
+
+
+interface TabContainerState extends RouteComponentProps {
+  only_show_running_backfills: boolean
+}
+
+class TabContainer extends React.Component<IState & IDispatchProps & TabContainerState,
+         IState & TabContainerState> {
   private tableTag = "services"
   private tableUrl = "/services"
 
   componentDidMount() {
+    const queryParams = new URLSearchParams(this.props.location.search);
+    const onlyShowRunningBackfillsQueryParam = queryParams.get('onlyShowActivelyRunning') == "true"
+    this.setState({ only_show_running_backfills: onlyShowRunningBackfillsQueryParam})
     this.props.simpleNetworkGet(this.tableTag, this.tableUrl)
   }
 
   render() {
-    return (
-      <LayoutContainer>
-        <ServicesListComponent
-          data={simpleSelectorGet(
-            this.props.simpleNetwork,
-            [this.tableTag, "data", "services"],
-            []
-          )}
-          url={this.tableUrl}
-          tag={this.tableTag}
-        />
-      </LayoutContainer>
-    )
+        if (!this.state) {
+          return (<div>loading...</div>)
+        } else {
+          return (
+            <LayoutContainer>
+              <FormGroup>
+                <Checkbox checked={this.state.only_show_running_backfills}
+                                label={"Only Services with running Backfills"}
+                                disabled={false}
+                                onChange={() => {
+                                  this.setState({ only_show_running_backfills: !this.state.only_show_running_backfills })
+                                }}
+                              />
+              </FormGroup>
+              <ServicesListComponent
+                data={simpleSelectorGet(
+                  this.props.simpleNetwork,
+                  [this.tableTag, "data", "services"],
+                  []
+                )}
+                url={this.tableUrl}
+                tag={this.tableTag}
+                onlyShowRunningBackfills={this.state.only_show_running_backfills}
+              />
+            </LayoutContainer>)
+          }
   }
 }
 


### PR DESCRIPTION
As a short term / quick fix for visualising backfills that are currently running, this adds the ability to filter the service list so we only show ones where running backfills is > 0.

- Add toggle to switch between modes.
- Use query parameter to allow linking directly


https://github.com/cashapp/backfila/assets/92703335/e9664f47-bad4-4ace-bba3-2a079fa3ab6f

