### PR TITLE
Remove suport for onlyShowActivelyRunning URL request parameter

### DIFF
--- a/service/web/tabs/app/src/containers/HomeContainer.tsx
+++ b/service/web/tabs/app/src/containers/HomeContainer.tsx
@@ -24,9 +24,7 @@ class TabContainer extends React.Component<IState & IDispatchProps & TabContaine
   private tableUrl = "/services"
 
   componentDidMount() {
-    const queryParams = new URLSearchParams(this.props.location.search);
-    const onlyShowRunningBackfillsQueryParam = queryParams.get('onlyShowActivelyRunning') == "true"
-    this.setState({ only_show_running_backfills: onlyShowRunningBackfillsQueryParam})
+    this.setState({ only_show_running_backfills: false})
     this.props.simpleNetworkGet(this.tableTag, this.tableUrl)
   }
 


### PR DESCRIPTION
The ability to switch modes via URL parameter was handy, but there was an issue with the routing in staging/prod that caused it not to work.

After having a play around with it as-is, it doesn't feel high value to try to fix it, so we'll just link directly to the list URL and the user can just click the check box to show active backfills.

Makes sense to simplify the code and remove it now that it's not going to be used