### PR TITLE
Change max argument limit 6k chars

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/BackfillCreator.kt
+++ b/service/src/main/kotlin/app/cash/backfila/BackfillCreator.kt
@@ -194,6 +194,6 @@ class BackfillCreator @Inject constructor(
   companion object {
     private val logger = getLogger<BackfillCreator>()
 
-    internal const val MAX_PARAMETER_VALUE_SIZE = 1000
+    internal const val MAX_PARAMETER_VALUE_SIZE = 6_000
   }
 }


### PR DESCRIPTION
6k chars will allow for 500 customer tokens (11 chars for customer token + 1 char to comma).

There are many use cases where we try to run a backfill for a small set of customers before running the full backfill. The previous max value of 1000, would only allow 83 tokens which is very restrictive.