### PR TITLE
Make Utf8StringNewlineStrategy class open

### DIFF
--- a/client-s3/src/main/kotlin/app/cash/backfila/client/s3/record/Utf8StringNewlineStrategy.kt
+++ b/client-s3/src/main/kotlin/app/cash/backfila/client/s3/record/Utf8StringNewlineStrategy.kt
@@ -6,7 +6,7 @@ import okio.ByteString
 /**
  * Produces single string records separated by newlines.
  */
-class Utf8StringNewlineStrategy(
+open class Utf8StringNewlineStrategy(
   private val ignoreBlankLines: Boolean = true,
 ) : RecordStrategy<String> {
   override fun calculateNextRecordBytes(source: BufferedSource): Long {


### PR DESCRIPTION
Make Utf8StringNewlineStrategy class open so that clients can extend the class and apply custom transformations.

For example:
```kotlin
class MyRecordStrategy() : Utf8StringNewlineStrategy(ignoreBlankLines = true) {
  override fun calculateNextRecordBytes =
    super.calculateNextRecordBytes(source).map(String::uppercase)
}

```