### PR TITLE
WIP: specify total backfilled records is in bytes

### DIFF
--- a/service/web/tabs/app/src/containers/BackfillStatusContainer.tsx
+++ b/service/web/tabs/app/src/containers/BackfillStatusContainer.tsx
@@ -297,11 +297,11 @@ class BackfillStatusContainer extends React.Component<
             </HTMLTable>
           </div>
           <div>
-            Total backfilled records:{" "}
+            Total backfilled records (bytes):{" "}
             {total_backfilled_matching_record_count.toLocaleString()}
           </div>
           <div>
-            Total records to run:{" "}
+            Total records to run (bytes):{" "}
             <ComputedCount
               precomputing_done={all_precomputing_done}
               computed_matching_record_count={


### PR DESCRIPTION
The UI for a backfill displays the total backfilled records as well as total records to run. 

<img width="653" alt="image" src="https://github.com/cashapp/backfila/assets/57500135/e57f79e1-24a1-4ccc-aa48-c1f72a7f89b5">

This is a bit misleading, because although this sounds like it is referring to the number of database items/records, this actually signifies bytes. This PR makes that clear.