### PR TITLE
Remove internal only OnStartup enum exposed in constructor

### DIFF
--- a/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/EmbeddedBackfilaModule.kt
+++ b/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/EmbeddedBackfilaModule.kt
@@ -10,10 +10,15 @@ import com.google.inject.AbstractModule
  * also need to install a [BackfillModule].
  */
 class EmbeddedBackfilaModule
-@JvmOverloads constructor(private val onStartup: OnStartup = OnStartup.THROW_ON_STARTUP) : AbstractModule() {
+@JvmOverloads constructor(
+  private val throwOnStartup: Boolean = true
+) : AbstractModule() {
   override fun configure() {
     bind(BackfilaApi::class.java).to(EmbeddedBackfila::class.java)
     bind(Backfila::class.java).to(EmbeddedBackfila::class.java)
-    bind(OnStartup::class.java).toInstance(onStartup)
+    bind(OnStartup::class.java).toInstance(
+      if (throwOnStartup) OnStartup.THROW_ON_STARTUP
+      else OnStartup.CONTINUE_ON_STARTUP
+    )
   }
 }

--- a/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/EmbeddedBackfilaModule.kt
+++ b/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/EmbeddedBackfilaModule.kt
@@ -11,7 +11,7 @@ import com.google.inject.AbstractModule
  */
 class EmbeddedBackfilaModule
 @JvmOverloads constructor(
-  private val throwOnStartup: Boolean = true
+  private val throwOnStartup: Boolean = true,
 ) : AbstractModule() {
   override fun configure() {
     bind(BackfilaApi::class.java).to(EmbeddedBackfila::class.java)

--- a/client-base/src/test/java/app/cash/backfila/embedded/annotations/TooManyAnnotationsModule.java
+++ b/client-base/src/test/java/app/cash/backfila/embedded/annotations/TooManyAnnotationsModule.java
@@ -1,12 +1,8 @@
 package app.cash.backfila.embedded.annotations;
 
-import app.cash.backfila.client.BackfilaApi;
 import app.cash.backfila.client.BackfilaHttpClientConfig;
-import app.cash.backfila.client.OnStartup;
 import app.cash.backfila.client.fixedset.FixedSetBackfillModule;
-import app.cash.backfila.client.internal.EmbeddedBackfila;
 import app.cash.backfila.client.misk.MiskBackfillModule;
-import app.cash.backfila.embedded.Backfila;
 import app.cash.backfila.embedded.EmbeddedBackfilaModule;
 import com.google.inject.AbstractModule;
 import misk.MiskTestingServiceModule;
@@ -33,6 +29,6 @@ public class TooManyAnnotationsModule extends AbstractModule {
     );
     install(FixedSetBackfillModule.create(TwoAnnotationParameterBackfill.class));
 
-    install(new EmbeddedBackfilaModule(OnStartup.CONTINUE_ON_STARTUP));
+    install(new EmbeddedBackfilaModule(false));
   }
 }


### PR DESCRIPTION
I think this was unintentionally exposed in a previous PR, and is now causing build issues across cash with
```
Cannot access class 'app.cash.backfila.client.OnStartup'. Check your module classpath for missing or conflicting dependencies
```