### PR TITLE
Expose the ability to check backfill status on BackfilaManagementClient

### DIFF
--- a/client-base/src/main/kotlin/app/cash/backfila/client/RealBackfilaManagementClient.kt
+++ b/client-base/src/main/kotlin/app/cash/backfila/client/RealBackfilaManagementClient.kt
@@ -23,8 +23,8 @@ class RealBackfilaManagementClient @Inject internal constructor(
     scan_size: Long?,
     pkey_range_start: ByteString?,
     pkey_range_end: ByteString?,
-  ) {
-    client.createAndStartBackfill(
+  ): Long {
+    return client.createAndStartBackfill(
       CreateAndStartBackfillRequest.Builder()
         .create_request(
           CreateBackfillRequest.Builder()
@@ -46,6 +46,6 @@ class RealBackfilaManagementClient @Inject internal constructor(
         )
         .variant(config.variant)
         .build(),
-    )
+    ).backfill_run_id ?: error("Failed to create and start backfill")
   }
 }

--- a/client-base/src/main/kotlin/app/cash/backfila/client/RealBackfilaManagementClient.kt
+++ b/client-base/src/main/kotlin/app/cash/backfila/client/RealBackfilaManagementClient.kt
@@ -48,7 +48,7 @@ class RealBackfilaManagementClient @Inject internal constructor(
         )
         .variant(config.variant)
         .build(),
-    ).backfill_run_id ?: error("Failed to create and start backfill")
+    ).backfill_run_id!!
   }
 
   override fun checkBackfillStatus(
@@ -58,6 +58,6 @@ class RealBackfilaManagementClient @Inject internal constructor(
       CheckBackfillStatusRequest.Builder()
         .backfill_run_id(backfill_run_id)
         .build(),
-    ).status
+    ).status!!
   }
 }

--- a/client-base/src/main/kotlin/app/cash/backfila/client/RealBackfilaManagementClient.kt
+++ b/client-base/src/main/kotlin/app/cash/backfila/client/RealBackfilaManagementClient.kt
@@ -2,6 +2,8 @@ package app.cash.backfila.client
 
 import app.cash.backfila.client.internal.BackfilaClient
 import app.cash.backfila.client.spi.parametersToBytes
+import app.cash.backfila.protos.service.CheckBackfillStatusRequest
+import app.cash.backfila.protos.service.CheckBackfillStatusResponse
 import app.cash.backfila.protos.service.CreateAndStartBackfillRequest
 import app.cash.backfila.protos.service.CreateBackfillRequest
 import javax.inject.Inject
@@ -47,5 +49,15 @@ class RealBackfilaManagementClient @Inject internal constructor(
         .variant(config.variant)
         .build(),
     ).backfill_run_id ?: error("Failed to create and start backfill")
+  }
+
+  override fun checkBackfillStatus(
+    backfill_run_id: Long,
+  ): CheckBackfillStatusResponse.Status {
+    return client.checkBackfillStatus(
+      CheckBackfillStatusRequest.Builder()
+        .backfill_run_id(backfill_run_id)
+        .build(),
+    ).status
   }
 }

--- a/client-misk-hibernate/src/test/kotlin/app/cash/backfila/client/misk/hibernate/BackfilaManagementClientTest.kt
+++ b/client-misk-hibernate/src/test/kotlin/app/cash/backfila/client/misk/hibernate/BackfilaManagementClientTest.kt
@@ -7,6 +7,7 @@ import app.cash.backfila.client.misk.ClientMiskService
 import app.cash.backfila.client.misk.ClientMiskTestingModule
 import app.cash.backfila.client.misk.DbMenu
 import app.cash.backfila.client.misk.MenuQuery
+import app.cash.backfila.protos.service.CheckBackfillStatusResponse
 import com.google.inject.Module
 import javax.inject.Inject
 import misk.hibernate.Id
@@ -37,6 +38,8 @@ class BackfilaManagementClientTest {
 
     val backfillId = managementClient.createAndStart(ChickenToBeefBackfill::class.java, dry_run = false)
     assertThat(backfillId).isNotNull()
+    val status = managementClient.checkBackfillStatus(backfillId)
+    assertThat(status).isEqualTo(CheckBackfillStatusResponse.Status.COMPLETE)
 
     val name = transacter.transaction { session ->
       session.load(id).name

--- a/client-misk-hibernate/src/test/kotlin/app/cash/backfila/client/misk/hibernate/BackfilaManagementClientTest.kt
+++ b/client-misk-hibernate/src/test/kotlin/app/cash/backfila/client/misk/hibernate/BackfilaManagementClientTest.kt
@@ -35,7 +35,8 @@ class BackfilaManagementClientTest {
       session.save(DbMenu("chicken"))
     }
 
-    managementClient.createAndStart(ChickenToBeefBackfill::class.java, dry_run = false)
+    val backfillId = managementClient.createAndStart(ChickenToBeefBackfill::class.java, dry_run = false)
+    assertThat(backfillId).isNotNull()
 
     val name = transacter.transaction { session ->
       session.load(id).name

--- a/client/src/main/kotlin/app/cash/backfila/client/BackfilaManagementClient.kt
+++ b/client/src/main/kotlin/app/cash/backfila/client/BackfilaManagementClient.kt
@@ -14,5 +14,5 @@ interface BackfilaManagementClient {
     scan_size: Long? = null,
     pkey_range_start: ByteString? = null,
     pkey_range_end: ByteString? = null,
-  )
+  ): Long
 }

--- a/client/src/main/kotlin/app/cash/backfila/client/BackfilaManagementClient.kt
+++ b/client/src/main/kotlin/app/cash/backfila/client/BackfilaManagementClient.kt
@@ -1,5 +1,6 @@
 package app.cash.backfila.client
 
+import app.cash.backfila.protos.service.CheckBackfillStatusResponse
 import okio.ByteString
 
 interface BackfilaManagementClient {
@@ -15,4 +16,8 @@ interface BackfilaManagementClient {
     pkey_range_start: ByteString? = null,
     pkey_range_end: ByteString? = null,
   ): Long
+
+  fun checkBackfillStatus(
+    backfill_run_id: Long,
+  ): CheckBackfillStatusResponse.Status
 }


### PR DESCRIPTION
Currently `BackfilaManagementClient` does not make it possible to check the status of a given backfill. This is due to two  problems:
- The run ID is not returned
- The API to fetch the status is not exposed

This PR addresses both of those issues