### PR TITLE
Update `code` element from extending screen width on extra parameters field

### DIFF
--- a/service/web/tabs/app/src/containers/BackfillStatusContainer.tsx
+++ b/service/web/tabs/app/src/containers/BackfillStatusContainer.tsx
@@ -289,7 +289,7 @@ class BackfillStatusContainer extends React.Component<
                       <td>{name}</td>
                       <td>
                       <code style={{ 
-                          wordBreak: "break-word", 
+                          wordBreak: "break-all", 
                           whiteSpace: "pre-wrap",
                           display: "block"
                         }}>{String(value)}</code>

--- a/service/web/tabs/app/src/containers/BackfillStatusContainer.tsx
+++ b/service/web/tabs/app/src/containers/BackfillStatusContainer.tsx
@@ -284,11 +284,15 @@ class BackfillStatusContainer extends React.Component<
                   </tr>
                 )}
                 {Object.entries(status.parameters).map(
-                  ([name, value]: [string, string]) => (
+                  ([name, value]) => (
                     <tr>
                       <td>{name}</td>
                       <td>
-                        <code>{value}</code>
+                      <code style={{ 
+                          wordBreak: "break-word", 
+                          whiteSpace: "pre-wrap",
+                          display: "block"
+                        }}>{String(value)}</code>
                       </td>
                     </tr>
                   )


### PR DESCRIPTION
On larger pieces of text, the code element spans the entire width of the screen and extends the text past the width of the page, which makes buttons on the right side of the screen hidden and hard to find without scrolling all the way over. 

Updated the styling on this element so that instead of making it overflow and extend the width of the page, we break the word into separate lines. Used `break-all` as opposed to `break-word`. 