### PR TITLE
Provide overridable method to hook into dynamo scan calls

### DIFF
--- a/client-dynamodb-v2/src/main/kotlin/app/cash/backfila/client/dynamodbv2/internal/DynamoDbBackfillOperator.kt
+++ b/client-dynamodb-v2/src/main/kotlin/app/cash/backfila/client/dynamodbv2/internal/DynamoDbBackfillOperator.kt
@@ -143,12 +143,8 @@ class DynamoDbBackfillOperator<I : Any, P : Any>(
 
       val result = dynamoDbClient.scan(scanRequest)
 
-      backfill.runBatch(
-        result.items().map {
-          backfill.dynamoDbTable.tableSchema().mapToItem(it)
-        },
-        config,
-      )
+      backfill.handleScanResponse(result, config)
+
       lastEvaluatedKey = result.lastEvaluatedKey()
       if (stopwatch.elapsed() > Duration.ofMillis(1_000L)) {
         break


### PR DESCRIPTION
I've found the limited access to the underlying dynamo api objects a bit restrictive. I'd like to expose a function that can be overridden to provide this access and optionally override batch handling behaviour.