### PR TITLE
Log create/clone/update errors to Datadog, not just browser UI

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/ui/actions/BackfillCreateHandlerAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/actions/BackfillCreateHandlerAction.kt
@@ -9,7 +9,6 @@ import app.cash.backfila.ui.pages.BackfillShowAction
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.html.div
-import misk.exceptions.BadRequestException
 import misk.scope.ActionScoped
 import misk.security.authz.Authenticated
 import misk.web.Get
@@ -22,6 +21,7 @@ import misk.web.mediatype.MediaTypes
 import misk.web.toResponseBody
 import okhttp3.Headers
 import okio.ByteString.Companion.encodeUtf8
+import wisp.logging.getLogger
 
 @Singleton
 class BackfillCreateHandlerAction @Inject constructor(
@@ -74,6 +74,7 @@ class BackfillCreateHandlerAction @Inject constructor(
             AlertError(message = "Backfill create or clone failed: $e", label = "Try Again", onClick = "history.back(); return false;")
           }
         }
+      logger.error(e) { "Backfill create or clone failed $e" }
       return Response(
         body = errorHtmlResponseBody,
         statusCode = 200,
@@ -91,6 +92,8 @@ class BackfillCreateHandlerAction @Inject constructor(
   }
 
   companion object {
+    private val logger = getLogger<BackfillCreateHandlerAction>()
+
     const val PATH = "/api/backfill/create"
 
     private fun <T>String?.ifNotBlank(block: (String) -> T) = if (this.isNullOrBlank()) null else block(this)

--- a/service/src/main/kotlin/app/cash/backfila/ui/actions/BackfillShowButtonHandlerAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/actions/BackfillShowButtonHandlerAction.kt
@@ -9,6 +9,8 @@ import app.cash.backfila.dashboard.UpdateBackfillRequest
 import app.cash.backfila.service.persistence.BackfillState
 import app.cash.backfila.ui.components.AlertError
 import app.cash.backfila.ui.components.DashboardPageLayout
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.html.div
 import misk.security.authz.Authenticated
 import misk.web.Get
@@ -21,8 +23,7 @@ import misk.web.actions.WebAction
 import misk.web.mediatype.MediaTypes
 import misk.web.toResponseBody
 import okhttp3.Headers
-import javax.inject.Inject
-import javax.inject.Singleton
+import wisp.logging.getLogger
 
 @Singleton
 class BackfillShowButtonHandlerAction @Inject constructor(
@@ -91,6 +92,7 @@ class BackfillShowButtonHandlerAction @Inject constructor(
             AlertError(message = "Update backfill field failed: $e", label = "Try Again", onClick = "history.back(); return false;")
           }
         }
+      logger.error(e) { "Update backfill field failed $e" }
       return Response(
         body = errorHtmlResponseBody,
         statusCode = 200,
@@ -106,6 +108,8 @@ class BackfillShowButtonHandlerAction @Inject constructor(
   }
 
   companion object {
+    private val logger = getLogger<BackfillShowButtonHandlerAction>()
+
     const val PATH = "/api/backfill/{id}/update"
     fun path(id: String) = PATH.replace("{id}", id)
     fun path(id: Long) = path(id.toString())


### PR DESCRIPTION
Previously, error would only show up in browser UI, but no stacktrace in Datadog / logs provider to be able to investigate fully.