### PR TITLE
Filter out empty string for default parameters

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/ui/actions/BackfillCreateHandlerAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/actions/BackfillCreateHandlerAction.kt
@@ -55,7 +55,7 @@ class BackfillCreateHandlerAction @Inject constructor(
       formFields[BackfillCreateField.THREADS_PER_PARTITION.fieldId]?.ifNotBlank { createRequestBuilder.num_threads(it.toIntOrNull()) }
       formFields[BackfillCreateField.EXTRA_SLEEP_MS.fieldId]?.ifNotBlank { createRequestBuilder.extra_sleep_ms(it.toLongOrNull()) }
       formFields[BackfillCreateField.BACKOFF_SCHEDULE.fieldId]?.ifNotBlank { createRequestBuilder.backoff_schedule(it) }
-      val customParameters = formFields.filter { it.key.startsWith(BackfillCreateField.CUSTOM_PARAMETER_PREFIX.fieldId) }
+      val customParameters = formFields.filter { it.key.startsWith(BackfillCreateField.CUSTOM_PARAMETER_PREFIX.fieldId) && !it.value.isNullOrBlank() }
         .map { it.key.removePrefix(BackfillCreateField.CUSTOM_PARAMETER_PREFIX.fieldId) to it.value?.encodeUtf8() }.toMap()
       if (customParameters.isNotEmpty()) {
         createRequestBuilder.parameter_map(customParameters)


### PR DESCRIPTION
Issue -  [slack](https://cash.slack.com/archives/C0151JAREE7/p1744123286097799?thread_ts=1744122786.155649&cid=C0151JAREE7)
Currently, all custom parameters that are unset are being defaulted to empty strings. This is causing validation to fail on the client side. Datadog [Link](https://square.datadoghq.com/logs?query=service%3Abackfila%20-status%3A%28warn%20OR%20info%29%20failed&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZY6nMEP2hdMuAAAABhBWlk2bk1JUUFBQnNDbDNHeGZnSlJnQ3IAAAAkMDE5NjNhOWUtMTdkZC00MGJjLWFmNjctNGRlNDE1MWRlNDM3AAneow&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1744691100571&to_ts=1744777500571&live=true)
![Screenshot 2025-04-08 at 10 41 03 AM](https://github.com/user-attachments/assets/ca2849ef-179c-4791-b8b0-d9d20f7c5497)

On the client side ([example](https://github.com/squareup/cash-business-payments/blob/6a279eba79a83386f11b96931ac476292fbffe05/service/src/main/kotlin/com/squareup/cash/cashbusinesspayments/backfill/TapToPayFirstPaymentTooltipBackfill.kt#L131-L196)), we use Kotlin data classes where parameters default to null if not provided. To align with this behavior, we should ignore parameters with empty string values rather than passing them through.
