### PR TITLE
Revamp S3 range validation with detailed message

### DIFF
--- a/client-s3/src/main/kotlin/app/cash/backfila/client/s3/internal/S3DatasourceBackfillOperator.kt
+++ b/client-s3/src/main/kotlin/app/cash/backfila/client/s3/internal/S3DatasourceBackfillOperator.kt
@@ -28,10 +28,7 @@ class S3DatasourceBackfillOperator<R : Any, P : Any>(
     val config = parametersOperator.constructBackfillConfig(request)
     backfill.validate(config)
 
-    require(
-      (request.range?.start == null && request.range?.end == null) ||
-        (request.range?.start?.utf8() == "0" && request.range?.end?.utf8() == "0")
-    ) {
+    require(request.range?.start == null && request.range?.end == null) {
       // We could think about supporting this later by making the range mean a byte seek into all S3 files.
       // This would mean we would need to support some kind of seek forward or seek back for record start.
       // That or perhaps we only support it for single file?

--- a/client-s3/src/main/kotlin/app/cash/backfila/client/s3/internal/S3DatasourceBackfillOperator.kt
+++ b/client-s3/src/main/kotlin/app/cash/backfila/client/s3/internal/S3DatasourceBackfillOperator.kt
@@ -28,7 +28,10 @@ class S3DatasourceBackfillOperator<R : Any, P : Any>(
     val config = parametersOperator.constructBackfillConfig(request)
     backfill.validate(config)
 
-    require(request.range?.start == null && request.range?.end == null) {
+    require(
+      (request.range?.start == null && request.range?.end == null) ||
+        (request.range?.start?.utf8() == "0" && request.range?.end?.utf8() == "0")
+    ) {
       // We could think about supporting this later by making the range mean a byte seek into all S3 files.
       // This would mean we would need to support some kind of seek forward or seek back for record start.
       // That or perhaps we only support it for single file?

--- a/client-s3/src/main/kotlin/app/cash/backfila/client/s3/internal/S3DatasourceBackfillOperator.kt
+++ b/client-s3/src/main/kotlin/app/cash/backfila/client/s3/internal/S3DatasourceBackfillOperator.kt
@@ -28,12 +28,12 @@ class S3DatasourceBackfillOperator<R : Any, P : Any>(
     val config = parametersOperator.constructBackfillConfig(request)
     backfill.validate(config)
 
-    require(request.range?.start == null && request.range?.end == null) {
+    require((request.range?.start?.utf8() == "0" || request.range?.start == null) && request.range?.end == null) {
       // We could think about supporting this later by making the range mean a byte seek into all S3 files.
       // This would mean we would need to support some kind of seek forward or seek back for record start.
       // That or perhaps we only support it for single file?
       // In any case, we are not implementing this now.
-      "Range is currently unsupported for S3 Backfils"
+      "Range is currently unsupported for S3 Backfils. Also when cloning an S3 backfill you must use a new blank range."
     }
 
     val pathPrefix = backfill.getPrefix(config)

--- a/service/src/main/kotlin/app/cash/backfila/ui/actions/BackfillCreateHandlerAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/actions/BackfillCreateHandlerAction.kt
@@ -56,7 +56,7 @@ class BackfillCreateHandlerAction @Inject constructor(
       when (formFields[BackfillCreateField.RANGE_OPTION.fieldId]) {
         RangeOption.CONTINUE.value -> {
           // Get the last processed position from the original backfill
-          val backfillId = formFields[BackfillCreateField.CLONE_BACKFILL_ID.fieldId]?.toLongOrNull()
+          val backfillId = formFields[BackfillCreateField.BACKFILL_ID_TO_CLONE.fieldId]?.toLongOrNull()
           backfillId?.let { id ->
             val status = getBackfillStatusAction.status(id)
             status.partitions.firstOrNull()?.let { partition ->
@@ -69,7 +69,7 @@ class BackfillCreateHandlerAction @Inject constructor(
         }
         RangeOption.RESTART.value -> {
           // Use the original range but start from beginning
-          val backfillId = formFields[BackfillCreateField.CLONE_BACKFILL_ID.fieldId]?.toLongOrNull()
+          val backfillId = formFields[BackfillCreateField.BACKFILL_ID_TO_CLONE.fieldId]?.toLongOrNull()
           backfillId?.let { id ->
             val status = getBackfillStatusAction.status(id)
             status.partitions.firstOrNull()?.let { partition ->

--- a/service/src/main/kotlin/app/cash/backfila/ui/actions/BackfillCreateHandlerAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/actions/BackfillCreateHandlerAction.kt
@@ -56,7 +56,7 @@ class BackfillCreateHandlerAction @Inject constructor(
       when (formFields[BackfillCreateField.RANGE_OPTION.fieldId]) {
         RangeOption.CONTINUE.value -> {
           // Get the last processed position from the original backfill
-          val backfillId = formFields[BackfillCreateField.BACKFILL_NAME.fieldId]?.toLongOrNull()
+          val backfillId = formFields[BackfillCreateField.CLONE_BACKFILL_ID.fieldId]?.toLongOrNull()
           backfillId?.let { id ->
             val status = getBackfillStatusAction.status(id)
             status.partitions.firstOrNull()?.let { partition ->
@@ -69,7 +69,7 @@ class BackfillCreateHandlerAction @Inject constructor(
         }
         RangeOption.RESTART.value -> {
           // Use the original range but start from beginning
-          val backfillId = formFields[BackfillCreateField.BACKFILL_NAME.fieldId]?.toLongOrNull()
+          val backfillId = formFields[BackfillCreateField.CLONE_BACKFILL_ID.fieldId]?.toLongOrNull()
           backfillId?.let { id ->
             val status = getBackfillStatusAction.status(id)
             status.partitions.firstOrNull()?.let { partition ->
@@ -77,6 +77,10 @@ class BackfillCreateHandlerAction @Inject constructor(
               partition.pkey_end?.let { createRequestBuilder.pkey_range_end(it.encodeUtf8()) }
             }
           }
+        }
+        RangeOption.NO_RANGE.value -> {
+          createRequestBuilder.pkey_range_start(null)
+          createRequestBuilder.pkey_range_end(null)
         }
         else -> {
           // For new range or non-clone cases, use the form values

--- a/service/src/main/kotlin/app/cash/backfila/ui/actions/BackfillCreateHandlerAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/actions/BackfillCreateHandlerAction.kt
@@ -78,10 +78,6 @@ class BackfillCreateHandlerAction @Inject constructor(
             }
           }
         }
-        RangeOption.NO_RANGE.value -> {
-          createRequestBuilder.pkey_range_start(null)
-          createRequestBuilder.pkey_range_end(null)
-        }
         else -> {
           // For new range or non-clone cases, use the form values
           formFields[BackfillCreateField.RANGE_START.fieldId]?.ifNotBlank { createRequestBuilder.pkey_range_start(it.encodeUtf8()) }

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
@@ -194,194 +194,290 @@ class BackfillCreateAction @Inject constructor(
                     }
                   }
 
-                  div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
-                    div("sm:col-span-3") {
-                      val field = BackfillCreateField.RANGE_START.fieldId
-                      label("block text-sm/6 font-medium text-gray-900") {
-                        htmlFor = field
-                        +"""Range Start (optional)"""
+                  // Range Options for cloning
+                  if (backfillToClone != null) {
+                    div("mt-6") {
+                      label("text-base font-semibold text-gray-900 block mb-4") {
+                        +"""Range Options"""
                       }
-                      div("mt-2") {
-                        input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
-                          type = InputType.number
-                          name = field
-                          id = field
-                          attributes["autocomplete"] = field
-                          // TODO is this how to clone?
-                          backfillToCloneStatus?.partitions?.firstOrNull()?.pkey_start?.let { value = it }
-                        }
-                      }
-                    }
-                    div("sm:col-span-3") {
-                      val field = BackfillCreateField.RANGE_END.fieldId
-                      label("block text-sm/6 font-medium text-gray-900") {
-                        htmlFor = field
-                        +"""Range End (optional)"""
-                      }
-                      div("mt-2") {
-                        input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
-                          type = InputType.number
-                          name = field
-                          id = field
-                          attributes["autocomplete"] = field
-                          // TODO is this how to clone?
-                          backfillToCloneStatus?.partitions?.firstOrNull()?.pkey_end?.let { value = it }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-
-              div("pt-12 space-y-12") {
-                div("border-b border-gray-900/10 pb-12") {
-                  h2("text-base/7 font-semibold text-gray-900") { +"""Mutable Options""" }
-                  p("mt-1 text-sm/6 text-gray-600") { +"""These options can be changed once the backfill is created.""" }
-
-                  div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
-                    div("sm:col-span-3") {
-                      val field = BackfillCreateField.BATCH_SIZE.fieldId
-                      label("block text-sm/6 font-medium text-gray-900") {
-                        htmlFor = field
-                        +"""Batch Size"""
-
-                        legend("text-sm/6 font-normal text-gray-900") { +"""How many *matching* records to send per call to RunBatch.""" }
-                      }
-                      div("mt-2") {
-                        input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
-                          type = InputType.text
-                          name = field
-                          id = field
-                          attributes["autocomplete"] = field
-                          value = "100"
-                          backfillToCloneStatus?.batch_size?.let { value = it.toString() }
-                        }
-                      }
-                    }
-                  }
-
-                  div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
-                    div("sm:col-span-3") {
-                      val field = BackfillCreateField.SCAN_SIZE.fieldId
-                      label("block text-sm/6 font-medium text-gray-900") {
-                        htmlFor = field
-                        +"""Scan Size"""
-
-                        legend("text-sm/6 font-normal text-gray-900") { +"""How many records to scan when computing batches.""" }
-                      }
-                      div("mt-2") {
-                        input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
-                          type = InputType.number
-                          name = field
-                          id = field
-                          attributes["autocomplete"] = field
-                          value = "10000"
-                          backfillToCloneStatus?.scan_size?.let { value = it.toString() }
-                        }
-                      }
-                    }
-                  }
-
-                  div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
-                    div("sm:col-span-3") {
-                      val field = BackfillCreateField.THREADS_PER_PARTITION.fieldId
-                      label("block text-sm/6 font-medium text-gray-900") {
-                        htmlFor = field
-                        +"""Threads Per Partition"""
-                      }
-                      div("mt-2") {
-                        input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
-                          type = InputType.number
-                          name = field
-                          id = field
-                          attributes["autocomplete"] = field
-                          value = "1"
-                          backfillToCloneStatus?.num_threads?.let { value = it.toString() }
-                        }
-                      }
-                    }
-                  }
-
-                  div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
-                    div("sm:col-span-3") {
-                      val field = BackfillCreateField.EXTRA_SLEEP_MS.fieldId
-                      label("block text-sm/6 font-medium text-gray-900") {
-                        htmlFor = field
-                        +"""Extra Sleep (ms)"""
-                      }
-                      div("mt-2") {
-                        input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
-                          type = InputType.number
-                          name = field
-                          id = field
-                          attributes["autocomplete"] = field
-                          value = "1"
-                          backfillToCloneStatus?.extra_sleep_ms?.let { value = it.toString() }
-                        }
-                      }
-                    }
-                  }
-
-                  div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
-                    div("sm:col-span-3") {
-                      val field = BackfillCreateField.BACKOFF_SCHEDULE.fieldId
-                      label("block text-sm/6 font-medium text-gray-900") {
-                        htmlFor = field
-                        +"""Backoff Schedule (optional)"""
-
-                        legend("text-sm/6 font-normal text-gray-900") { +"""Comma separated list of milliseconds to backoff subsequent failures.""" }
-                      }
-                      div("mt-2") {
-                        input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
-                          type = InputType.text
-                          name = field
-                          id = field
-                          attributes["autocomplete"] = field
-                          placeholder = "5000,15000,30000"
-                          backfillToCloneStatus?.backoff_schedule?.let { value = it }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-
-              // Custom Parameters
-              if (registeredBackfill?.parameterNames?.isNotEmpty() == true) {
-                div("pt-12 space-y-12") {
-                  div("border-b border-gray-900/10 pb-12") {
-                    h2("text-base/7 font-semibold text-gray-900") { +"""Immutable Custom Parameters""" }
-                    p("mt-1 text-sm/6 text-gray-600") { +"""These custom parameters can't be changed once the backfill is created.""" }
-
-                    registeredBackfill.parameterNames.map {
-                      div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
-                        div("sm:col-span-3") {
-                          val field = "${BackfillCreateField.CUSTOM_PARAMETER_PREFIX.fieldId}$it"
-                          label("block text-sm/6 font-medium text-gray-900") {
-                            htmlFor = field
-                            +it
+                      div("space-y-4") {
+                        // Same range, restart from beginning
+                        div("flex items-center") {
+                          input(classes = "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600") {
+                            id = "range-option-restart"
+                            name = BackfillCreateField.RANGE_OPTION.fieldId
+                            type = InputType.radio
+                            value = RangeOption.RESTART.value
+                            checked = true // Default option
                           }
-                          div("mt-2") {
-                            input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
-                              type = InputType.text
-                              name = field
-                              id = field
-                              attributes["autocomplete"] = field
-                              backfillToCloneStatus?.parameters?.get(it)?.let { value = it }
+                          label("ml-3 block text-sm font-medium leading-6 text-gray-900") {
+                            htmlFor = "range-option-restart"
+                            +"""Same range, restart from beginning"""
+                          }
+                        }
+
+                        // Same range, continue from last processed
+                        div("flex items-center") {
+                          input(classes = "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600") {
+                            id = "range-option-continue"
+                            name = BackfillCreateField.RANGE_OPTION.fieldId
+                            type = InputType.radio
+                            value = RangeOption.CONTINUE.value
+                          }
+                          label("ml-3 block text-sm font-medium leading-6 text-gray-900") {
+                            htmlFor = "range-option-continue"
+                            +"""Same range, continue from last processed"""
+                          }
+                        }
+
+                        // New range with embedded range fields
+                        div("flex items-center") {
+                          input(classes = "peer/new h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600") {
+                            id = "range-option-new"
+                            name = BackfillCreateField.RANGE_OPTION.fieldId
+                            type = InputType.radio
+                            value = RangeOption.NEW.value
+                          }
+                          label("ml-3 block text-sm font-medium leading-6 text-gray-900") {
+                            htmlFor = "range-option-new"
+                            +"""New range"""
+                          }
+
+                          // Range input fields - shown when "New range" is selected
+                          div("mt-4 ml-7 hidden peer-checked/new:block") {
+                            div("grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-6") {
+                              div("sm:col-span-3") {
+                                val field = BackfillCreateField.RANGE_START.fieldId
+                                label("block text-sm/6 font-medium text-gray-900") {
+                                  htmlFor = field
+                                  +"""Range Start (optional)"""
+                                }
+                                div("mt-2") {
+                                  input(
+                                    classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6",
+                                  ) {
+                                    type = InputType.number
+                                    name = field
+                                    id = field
+                                    attributes["autocomplete"] = field
+                                    backfillToCloneStatus?.partitions?.firstOrNull()?.pkey_start?.let {
+                                      value = it
+                                    }
+                                  }
+                                }
+                              }
+                              div("sm:col-span-3") {
+                                val field = BackfillCreateField.RANGE_END.fieldId
+                                label("block text-sm/6 font-medium text-gray-900") {
+                                  htmlFor = field
+                                  +"""Range End (optional)"""
+                                }
+                                div("mt-2") {
+                                  input(
+                                    classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6",
+                                  ) {
+                                    type = InputType.number
+                                    name = field
+                                    id = field
+                                    attributes["autocomplete"] = field
+                                    backfillToCloneStatus?.partitions?.firstOrNull()?.pkey_end?.let {
+                                      value = it
+                                    }
+                                  }
+                                }
+                              }
                             }
                           }
                         }
                       }
                     }
+                  } else {
+                    // Range fields for new backfills (non-clone case)
+                    div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
+                      div("sm:col-span-3") {
+                        val field = BackfillCreateField.RANGE_START.fieldId
+                        label("block text-sm/6 font-medium text-gray-900") {
+                          htmlFor = field
+                          +"""Range Start (optional)"""
+                        }
+                        div("mt-2") {
+                          input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
+                            type = InputType.number
+                            name = field
+                            id = field
+                            attributes["autocomplete"] = field
+                          }
+                        }
+                      }
+                      div("sm:col-span-3") {
+                        val field = BackfillCreateField.RANGE_END.fieldId
+                        label("block text-sm/6 font-medium text-gray-900") {
+                          htmlFor = field
+                          +"""Range End (optional)"""
+                        }
+                        div("mt-2") {
+                          input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
+                            type = InputType.number
+                            name = field
+                            id = field
+                            attributes["autocomplete"] = field
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
+            }
 
-              button(classes = "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600") {
-                type = ButtonType.submit
+            div("pt-12 space-y-12") {
+              div("border-b border-gray-900/10 pb-12") {
+                h2("text-base/7 font-semibold text-gray-900") { +"""Mutable Options""" }
+                p("mt-1 text-sm/6 text-gray-600") { +"""These options can be changed once the backfill is created.""" }
 
-                +cloneOrCreate
+                div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
+                  div("sm:col-span-3") {
+                    val field = BackfillCreateField.BATCH_SIZE.fieldId
+                    label("block text-sm/6 font-medium text-gray-900") {
+                      htmlFor = field
+                      +"""Batch Size"""
+
+                      legend("text-sm/6 font-normal text-gray-900") { +"""How many *matching* records to send per call to RunBatch.""" }
+                    }
+                    div("mt-2") {
+                      input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
+                        type = InputType.text
+                        name = field
+                        id = field
+                        attributes["autocomplete"] = field
+                        value = "100"
+                        backfillToCloneStatus?.batch_size?.let { value = it.toString() }
+                      }
+                    }
+                  }
+                }
+
+                div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
+                  div("sm:col-span-3") {
+                    val field = BackfillCreateField.SCAN_SIZE.fieldId
+                    label("block text-sm/6 font-medium text-gray-900") {
+                      htmlFor = field
+                      +"""Scan Size"""
+
+                      legend("text-sm/6 font-normal text-gray-900") { +"""How many records to scan when computing batches.""" }
+                    }
+                    div("mt-2") {
+                      input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
+                        type = InputType.number
+                        name = field
+                        id = field
+                        attributes["autocomplete"] = field
+                        value = "10000"
+                        backfillToCloneStatus?.scan_size?.let { value = it.toString() }
+                      }
+                    }
+                  }
+                }
+
+                div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
+                  div("sm:col-span-3") {
+                    val field = BackfillCreateField.THREADS_PER_PARTITION.fieldId
+                    label("block text-sm/6 font-medium text-gray-900") {
+                      htmlFor = field
+                      +"""Threads Per Partition"""
+                    }
+                    div("mt-2") {
+                      input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
+                        type = InputType.number
+                        name = field
+                        id = field
+                        attributes["autocomplete"] = field
+                        value = "1"
+                        backfillToCloneStatus?.num_threads?.let { value = it.toString() }
+                      }
+                    }
+                  }
+                }
+
+                div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
+                  div("sm:col-span-3") {
+                    val field = BackfillCreateField.EXTRA_SLEEP_MS.fieldId
+                    label("block text-sm/6 font-medium text-gray-900") {
+                      htmlFor = field
+                      +"""Extra Sleep (ms)"""
+                    }
+                    div("mt-2") {
+                      input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
+                        type = InputType.number
+                        name = field
+                        id = field
+                        attributes["autocomplete"] = field
+                        value = "1"
+                        backfillToCloneStatus?.extra_sleep_ms?.let { value = it.toString() }
+                      }
+                    }
+                  }
+                }
+
+                div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
+                  div("sm:col-span-3") {
+                    val field = BackfillCreateField.BACKOFF_SCHEDULE.fieldId
+                    label("block text-sm/6 font-medium text-gray-900") {
+                      htmlFor = field
+                      +"""Backoff Schedule (optional)"""
+
+                      legend("text-sm/6 font-normal text-gray-900") { +"""Comma separated list of milliseconds to backoff subsequent failures.""" }
+                    }
+                    div("mt-2") {
+                      input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
+                        type = InputType.text
+                        name = field
+                        id = field
+                        attributes["autocomplete"] = field
+                        placeholder = "5000,15000,30000"
+                        backfillToCloneStatus?.backoff_schedule?.let { value = it }
+                      }
+                    }
+                  }
+                }
               }
+            }
+
+            // Custom Parameters
+            if (registeredBackfill?.parameterNames?.isNotEmpty() == true) {
+              div("pt-12 space-y-12") {
+                div("border-b border-gray-900/10 pb-12") {
+                  h2("text-base/7 font-semibold text-gray-900") { +"""Immutable Custom Parameters""" }
+                  p("mt-1 text-sm/6 text-gray-600") { +"""These custom parameters can't be changed once the backfill is created.""" }
+
+                  registeredBackfill.parameterNames.map {
+                    div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
+                      div("sm:col-span-3") {
+                        val field = "${BackfillCreateField.CUSTOM_PARAMETER_PREFIX.fieldId}$it"
+                        label("block text-sm/6 font-medium text-gray-900") {
+                          htmlFor = field
+                          +it
+                        }
+                        div("mt-2") {
+                          input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
+                            type = InputType.text
+                            name = field
+                            id = field
+                            attributes["autocomplete"] = field
+                            backfillToCloneStatus?.parameters?.get(it)?.let { value = it }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+
+            button(classes = "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600") {
+              type = ButtonType.submit
+
+              +cloneOrCreate
             }
           }
         }
@@ -395,6 +491,7 @@ class BackfillCreateAction @Inject constructor(
     VARIANT("variant"),
     BACKFILL_NAME("backfillName"),
     DRY_RUN("dryRun"),
+    RANGE_OPTION("rangeOption"),
     RANGE_START("rangeStart"),
     RANGE_END("rangeEnd"),
     BATCH_SIZE("batchSize"),
@@ -403,6 +500,12 @@ class BackfillCreateAction @Inject constructor(
     EXTRA_SLEEP_MS("extraSleepMs"),
     BACKOFF_SCHEDULE("backoffSchedule"),
     CUSTOM_PARAMETER_PREFIX("customParameter_"),
+  }
+
+  enum class RangeOption(val value: String) {
+    RESTART("restart"),
+    CONTINUE("continue"),
+    NEW("new");
   }
 
   companion object {

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
@@ -260,9 +260,6 @@ class BackfillCreateAction @Inject constructor(
                                     name = field
                                     id = field
                                     attributes["autocomplete"] = field
-                                    backfillToCloneStatus?.partitions?.firstOrNull()?.pkey_start?.let {
-                                      value = it
-                                    }
                                   }
                                 }
                               }
@@ -280,9 +277,6 @@ class BackfillCreateAction @Inject constructor(
                                     name = field
                                     id = field
                                     attributes["autocomplete"] = field
-                                    backfillToCloneStatus?.partitions?.firstOrNull()?.pkey_end?.let {
-                                      value = it
-                                    }
                                   }
                                 }
                               }

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
@@ -505,7 +505,7 @@ class BackfillCreateAction @Inject constructor(
   enum class RangeOption(val value: String) {
     RESTART("restart"),
     CONTINUE("continue"),
-    NEW("new");
+    NEW("new"),
   }
 
   companion object {

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
@@ -152,7 +152,7 @@ class BackfillCreateAction @Inject constructor(
 
               input {
                 type = InputType.hidden
-                name = BackfillCreateField.CLONE_BACKFILL_ID.fieldId
+                name = BackfillCreateField.BACKFILL_ID_TO_CLONE.fieldId
                 value = backfillIdToClone ?: ""
               }
 
@@ -503,7 +503,7 @@ class BackfillCreateAction @Inject constructor(
     SERVICE("service"),
     VARIANT("variant"),
     BACKFILL_NAME("backfillName"),
-    CLONE_BACKFILL_ID("cloneBackfillId"),
+    BACKFILL_ID_TO_CLONE("backfillIdToClone"),
     DRY_RUN("dryRun"),
     RANGE_OPTION("rangeOption"),
     RANGE_START("rangeStart"),

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
@@ -236,19 +236,6 @@ class BackfillCreateAction @Inject constructor(
                           }
                         }
 
-                        div("flex items-center") {
-                          input(classes = "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600") {
-                            id = "range-option-no-range"
-                            name = BackfillCreateField.RANGE_OPTION.fieldId
-                            type = InputType.radio
-                            value = RangeOption.NO_RANGE.value
-                          }
-                          label("ml-3 block text-sm font-medium leading-6 text-gray-900") {
-                            htmlFor = "range-option-no-range"
-                            +"""No range"""
-                          }
-                        }
-
                         // New range with embedded range fields
                         div("flex items-center") {
                           input(classes = "peer/new h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600") {
@@ -520,7 +507,6 @@ class BackfillCreateAction @Inject constructor(
     RESTART("restart"),
     CONTINUE("continue"),
     NEW("new"),
-    NO_RANGE("no_range"),
   }
 
   companion object {

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
@@ -150,6 +150,12 @@ class BackfillCreateAction @Inject constructor(
                 value = resolvedBackfillName
               }
 
+              input {
+                type = InputType.hidden
+                name = BackfillCreateField.CLONE_BACKFILL_ID.fieldId
+                value = backfillIdToClone ?: ""
+              }
+
               div("space-y-12") {
                 div("border-b border-gray-900/10 pb-12") {
                   h2("text-base/7 font-semibold text-gray-900") { +"""Immutable Options""" }
@@ -227,6 +233,19 @@ class BackfillCreateAction @Inject constructor(
                           label("ml-3 block text-sm font-medium leading-6 text-gray-900") {
                             htmlFor = "range-option-continue"
                             +"""Same range, continue from last processed"""
+                          }
+                        }
+
+                        div("flex items-center") {
+                          input(classes = "h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-600") {
+                            id = "range-option-no-range"
+                            name = BackfillCreateField.RANGE_OPTION.fieldId
+                            type = InputType.radio
+                            value = RangeOption.NO_RANGE.value
+                          }
+                          label("ml-3 block text-sm font-medium leading-6 text-gray-900") {
+                            htmlFor = "range-option-no-range"
+                            +"""No range"""
                           }
                         }
 
@@ -484,6 +503,7 @@ class BackfillCreateAction @Inject constructor(
     SERVICE("service"),
     VARIANT("variant"),
     BACKFILL_NAME("backfillName"),
+    CLONE_BACKFILL_ID("cloneBackfillId"),
     DRY_RUN("dryRun"),
     RANGE_OPTION("rangeOption"),
     RANGE_START("rangeStart"),
@@ -500,6 +520,7 @@ class BackfillCreateAction @Inject constructor(
     RESTART("restart"),
     CONTINUE("continue"),
     NEW("new"),
+    NO_RANGE("no_range"),
   }
 
   companion object {

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
@@ -322,143 +322,143 @@ class BackfillCreateAction @Inject constructor(
                   }
                 }
               }
-            }
 
-            div("pt-12 space-y-12") {
-              div("border-b border-gray-900/10 pb-12") {
-                h2("text-base/7 font-semibold text-gray-900") { +"""Mutable Options""" }
-                p("mt-1 text-sm/6 text-gray-600") { +"""These options can be changed once the backfill is created.""" }
+              div("pt-12 space-y-12") {
+                div("border-b border-gray-900/10 pb-12") {
+                  h2("text-base/7 font-semibold text-gray-900") { +"""Mutable Options""" }
+                  p("mt-1 text-sm/6 text-gray-600") { +"""These options can be changed once the backfill is created.""" }
 
-                div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
-                  div("sm:col-span-3") {
-                    val field = BackfillCreateField.BATCH_SIZE.fieldId
-                    label("block text-sm/6 font-medium text-gray-900") {
-                      htmlFor = field
-                      +"""Batch Size"""
+                  div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
+                    div("sm:col-span-3") {
+                      val field = BackfillCreateField.BATCH_SIZE.fieldId
+                      label("block text-sm/6 font-medium text-gray-900") {
+                        htmlFor = field
+                        +"""Batch Size"""
 
-                      legend("text-sm/6 font-normal text-gray-900") { +"""How many *matching* records to send per call to RunBatch.""" }
-                    }
-                    div("mt-2") {
-                      input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
-                        type = InputType.text
-                        name = field
-                        id = field
-                        attributes["autocomplete"] = field
-                        value = "100"
-                        backfillToCloneStatus?.batch_size?.let { value = it.toString() }
+                        legend("text-sm/6 font-normal text-gray-900") { +"""How many *matching* records to send per call to RunBatch.""" }
+                      }
+                      div("mt-2") {
+                        input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
+                          type = InputType.text
+                          name = field
+                          id = field
+                          attributes["autocomplete"] = field
+                          value = "100"
+                          backfillToCloneStatus?.batch_size?.let { value = it.toString() }
+                        }
                       }
                     }
                   }
-                }
 
-                div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
-                  div("sm:col-span-3") {
-                    val field = BackfillCreateField.SCAN_SIZE.fieldId
-                    label("block text-sm/6 font-medium text-gray-900") {
-                      htmlFor = field
-                      +"""Scan Size"""
+                  div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
+                    div("sm:col-span-3") {
+                      val field = BackfillCreateField.SCAN_SIZE.fieldId
+                      label("block text-sm/6 font-medium text-gray-900") {
+                        htmlFor = field
+                        +"""Scan Size"""
 
-                      legend("text-sm/6 font-normal text-gray-900") { +"""How many records to scan when computing batches.""" }
-                    }
-                    div("mt-2") {
-                      input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
-                        type = InputType.number
-                        name = field
-                        id = field
-                        attributes["autocomplete"] = field
-                        value = "10000"
-                        backfillToCloneStatus?.scan_size?.let { value = it.toString() }
+                        legend("text-sm/6 font-normal text-gray-900") { +"""How many records to scan when computing batches.""" }
+                      }
+                      div("mt-2") {
+                        input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
+                          type = InputType.number
+                          name = field
+                          id = field
+                          attributes["autocomplete"] = field
+                          value = "10000"
+                          backfillToCloneStatus?.scan_size?.let { value = it.toString() }
+                        }
                       }
                     }
                   }
-                }
 
-                div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
-                  div("sm:col-span-3") {
-                    val field = BackfillCreateField.THREADS_PER_PARTITION.fieldId
-                    label("block text-sm/6 font-medium text-gray-900") {
-                      htmlFor = field
-                      +"""Threads Per Partition"""
-                    }
-                    div("mt-2") {
-                      input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
-                        type = InputType.number
-                        name = field
-                        id = field
-                        attributes["autocomplete"] = field
-                        value = "1"
-                        backfillToCloneStatus?.num_threads?.let { value = it.toString() }
+                  div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
+                    div("sm:col-span-3") {
+                      val field = BackfillCreateField.THREADS_PER_PARTITION.fieldId
+                      label("block text-sm/6 font-medium text-gray-900") {
+                        htmlFor = field
+                        +"""Threads Per Partition"""
+                      }
+                      div("mt-2") {
+                        input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
+                          type = InputType.number
+                          name = field
+                          id = field
+                          attributes["autocomplete"] = field
+                          value = "1"
+                          backfillToCloneStatus?.num_threads?.let { value = it.toString() }
+                        }
                       }
                     }
                   }
-                }
 
-                div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
-                  div("sm:col-span-3") {
-                    val field = BackfillCreateField.EXTRA_SLEEP_MS.fieldId
-                    label("block text-sm/6 font-medium text-gray-900") {
-                      htmlFor = field
-                      +"""Extra Sleep (ms)"""
-                    }
-                    div("mt-2") {
-                      input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
-                        type = InputType.number
-                        name = field
-                        id = field
-                        attributes["autocomplete"] = field
-                        value = "1"
-                        backfillToCloneStatus?.extra_sleep_ms?.let { value = it.toString() }
+                  div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
+                    div("sm:col-span-3") {
+                      val field = BackfillCreateField.EXTRA_SLEEP_MS.fieldId
+                      label("block text-sm/6 font-medium text-gray-900") {
+                        htmlFor = field
+                        +"""Extra Sleep (ms)"""
+                      }
+                      div("mt-2") {
+                        input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
+                          type = InputType.number
+                          name = field
+                          id = field
+                          attributes["autocomplete"] = field
+                          value = "1"
+                          backfillToCloneStatus?.extra_sleep_ms?.let { value = it.toString() }
+                        }
                       }
                     }
                   }
-                }
 
-                div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
-                  div("sm:col-span-3") {
-                    val field = BackfillCreateField.BACKOFF_SCHEDULE.fieldId
-                    label("block text-sm/6 font-medium text-gray-900") {
-                      htmlFor = field
-                      +"""Backoff Schedule (optional)"""
+                  div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
+                    div("sm:col-span-3") {
+                      val field = BackfillCreateField.BACKOFF_SCHEDULE.fieldId
+                      label("block text-sm/6 font-medium text-gray-900") {
+                        htmlFor = field
+                        +"""Backoff Schedule (optional)"""
 
-                      legend("text-sm/6 font-normal text-gray-900") { +"""Comma separated list of milliseconds to backoff subsequent failures.""" }
-                    }
-                    div("mt-2") {
-                      input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
-                        type = InputType.text
-                        name = field
-                        id = field
-                        attributes["autocomplete"] = field
-                        placeholder = "5000,15000,30000"
-                        backfillToCloneStatus?.backoff_schedule?.let { value = it }
+                        legend("text-sm/6 font-normal text-gray-900") { +"""Comma separated list of milliseconds to backoff subsequent failures.""" }
+                      }
+                      div("mt-2") {
+                        input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
+                          type = InputType.text
+                          name = field
+                          id = field
+                          attributes["autocomplete"] = field
+                          placeholder = "5000,15000,30000"
+                          backfillToCloneStatus?.backoff_schedule?.let { value = it }
+                        }
                       }
                     }
                   }
                 }
               }
-            }
 
-            // Custom Parameters
-            if (registeredBackfill?.parameterNames?.isNotEmpty() == true) {
-              div("pt-12 space-y-12") {
-                div("border-b border-gray-900/10 pb-12") {
-                  h2("text-base/7 font-semibold text-gray-900") { +"""Immutable Custom Parameters""" }
-                  p("mt-1 text-sm/6 text-gray-600") { +"""These custom parameters can't be changed once the backfill is created.""" }
+              // Custom Parameters
+              if (registeredBackfill?.parameterNames?.isNotEmpty() == true) {
+                div("pt-12 space-y-12") {
+                  div("border-b border-gray-900/10 pb-12") {
+                    h2("text-base/7 font-semibold text-gray-900") { +"""Immutable Custom Parameters""" }
+                    p("mt-1 text-sm/6 text-gray-600") { +"""These custom parameters can't be changed once the backfill is created.""" }
 
-                  registeredBackfill.parameterNames.map {
-                    div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
-                      div("sm:col-span-3") {
-                        val field = "${BackfillCreateField.CUSTOM_PARAMETER_PREFIX.fieldId}$it"
-                        label("block text-sm/6 font-medium text-gray-900") {
-                          htmlFor = field
-                          +it
-                        }
-                        div("mt-2") {
-                          input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
-                            type = InputType.text
-                            name = field
-                            id = field
-                            attributes["autocomplete"] = field
-                            backfillToCloneStatus?.parameters?.get(it)?.let { value = it }
+                    registeredBackfill.parameterNames.map {
+                      div("mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6") {
+                        div("sm:col-span-3") {
+                          val field = "${BackfillCreateField.CUSTOM_PARAMETER_PREFIX.fieldId}$it"
+                          label("block text-sm/6 font-medium text-gray-900") {
+                            htmlFor = field
+                            +it
+                          }
+                          div("mt-2") {
+                            input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
+                              type = InputType.text
+                              name = field
+                              id = field
+                              attributes["autocomplete"] = field
+                              backfillToCloneStatus?.parameters?.get(it)?.let { value = it }
+                            }
                           }
                         }
                       }
@@ -466,12 +466,12 @@ class BackfillCreateAction @Inject constructor(
                   }
                 }
               }
-            }
 
-            button(classes = "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600") {
-              type = ButtonType.submit
+              button(classes = "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600") {
+                type = ButtonType.submit
 
-              +cloneOrCreate
+                +cloneOrCreate
+              }
             }
           }
         }


### PR DESCRIPTION
Revamp S3 range validation with detailed message and allow 0 as the range start value. 

For S3 Backfills - 
The range isn’t actually defaulting to 0 — what’s happening is that it’s cloning the values from the previous run. For example, [this run](https://backfila.sqprod.co/backfills/28700) has a range of 0 to null.  So when cloned, the start value of 0 gets copied over. On the other hand, [this run](https://backfila.sqprod.co/backfills/28806) has both start and end as null, so those values are cloned instead.

This means that if a previous run had a start value of 0, and the user selects RESTART, that 0 will be reused — which can will cause errors for S3 since valid range should not be there. To avoid this, We want to support a start value of 0 for S3 backfills.