### PR TITLE
Add loggings and allow 0 as range start for s3 backfills

### DIFF
--- a/client-s3/src/main/kotlin/app/cash/backfila/client/s3/internal/S3DatasourceBackfillOperator.kt
+++ b/client-s3/src/main/kotlin/app/cash/backfila/client/s3/internal/S3DatasourceBackfillOperator.kt
@@ -27,13 +27,13 @@ class S3DatasourceBackfillOperator<R : Any, P : Any>(
   override fun prepareBackfill(request: PrepareBackfillRequest): PrepareBackfillResponse {
     val config = parametersOperator.constructBackfillConfig(request)
     backfill.validate(config)
-
-    require(request.range?.start == null && request.range?.end == null) {
+    val isRangeValid = (request.range?.start?.utf8() == "0" || request.range?.start == null) && request.range?.end == null
+    require(isRangeValid) {
       // We could think about supporting this later by making the range mean a byte seek into all S3 files.
       // This would mean we would need to support some kind of seek forward or seek back for record start.
       // That or perhaps we only support it for single file?
       // In any case, we are not implementing this now.
-      "Range is currently unsupported for S3 Backfils"
+      "Ranges are not currently supported for S3 Backfills. Additionally, cloning an S3 backfill requires using a new empty range."
     }
 
     val pathPrefix = backfill.getPrefix(config)

--- a/client-s3/src/main/kotlin/app/cash/backfila/client/s3/internal/S3DatasourceBackfillOperator.kt
+++ b/client-s3/src/main/kotlin/app/cash/backfila/client/s3/internal/S3DatasourceBackfillOperator.kt
@@ -33,7 +33,7 @@ class S3DatasourceBackfillOperator<R : Any, P : Any>(
       // This would mean we would need to support some kind of seek forward or seek back for record start.
       // That or perhaps we only support it for single file?
       // In any case, we are not implementing this now.
-      "Ranges are not currently supported for S3 Backfills. Additionally, cloning an S3 backfill requires using a new empty range."
+      "Only full ranges are currently supported for S3 Backfills."
     }
 
     val pathPrefix = backfill.getPrefix(config)

--- a/client-s3/src/test/kotlin/app/cash/backfila/client/s3/S3Utf8StringNewlineBackfillTest.kt
+++ b/client-s3/src/test/kotlin/app/cash/backfila/client/s3/S3Utf8StringNewlineBackfillTest.kt
@@ -112,12 +112,12 @@ class S3Utf8StringNewlineBackfillTest {
       this.assertThatCode {
         backfila.createWetRun<BreakfastBackfill>(rangeStart = "a start")
         fail("invalid range must fail")
-      }.hasMessageContaining("Ranges are not currently supported for S3 Backfills. Additionally, cloning an S3 backfill requires using a new empty range.")
+      }.hasMessageContaining("Only full ranges are currently supported for S3 Backfills.")
 
       this.assertThatCode {
         backfila.createWetRun<BreakfastBackfill>(rangeEnd = "a end")
         fail("invalid range must fail")
-      }.hasMessageContaining("Ranges are not currently supported for S3 Backfills. Additionally, cloning an S3 backfill requires using a new empty range.")
+      }.hasMessageContaining("Only full ranges are currently supported for S3 Backfills.")
 
       this.assertThatCode {
         backfila.createWetRun<BrunchBackfill>()

--- a/client-s3/src/test/kotlin/app/cash/backfila/client/s3/S3Utf8StringNewlineBackfillTest.kt
+++ b/client-s3/src/test/kotlin/app/cash/backfila/client/s3/S3Utf8StringNewlineBackfillTest.kt
@@ -112,12 +112,12 @@ class S3Utf8StringNewlineBackfillTest {
       this.assertThatCode {
         backfila.createWetRun<BreakfastBackfill>(rangeStart = "a start")
         fail("invalid range must fail")
-      }.hasMessageContaining("Range is currently unsupported")
+      }.hasMessageContaining("Ranges are not currently supported for S3 Backfills. Additionally, cloning an S3 backfill requires using a new empty range.")
 
       this.assertThatCode {
         backfila.createWetRun<BreakfastBackfill>(rangeEnd = "a end")
         fail("invalid range must fail")
-      }.hasMessageContaining("Range is currently unsupported")
+      }.hasMessageContaining("Ranges are not currently supported for S3 Backfills. Additionally, cloning an S3 backfill requires using a new empty range.")
 
       this.assertThatCode {
         backfila.createWetRun<BrunchBackfill>()


### PR DESCRIPTION
Revamp S3 range validation with detailed message and allow 0 as the range start value.

For S3 Backfills -
The range isn’t actually defaulting to 0 — what’s happening is that it’s cloning the values from the previous run. For example, [this run](https://backfila.sqprod.co/backfills/28700) has a range of 0 to null. So when cloned, the start value of 0 gets copied over. On the other hand, [this run](https://backfila.sqprod.co/backfills/28806) has both start and end as null, so those values are cloned instead.

This means that if a previous run had a start value of 0, and the user selects RESTART, that 0 will be reused — which can will cause errors for S3 since valid range should not be there. To avoid this, We want to support a start value of 0 for S3 backfills.

current logging user get - 
![Screenshot 2025-04-17 at 2 21 46 PM](https://github.com/user-attachments/assets/00b768c2-bd6d-47dd-bed6-e98e193536ee)

