### PR TITLE
Add proper state handling for rate display on the new UI

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
@@ -180,7 +180,7 @@ class BackfillShowAction @Inject constructor(
                     td("hidden py-5 pl-8 pr-0 text-right align-top tabular-nums text-gray-700 sm:table-cell") {
                       when {
                         partition.state != BackfillState.RUNNING -> +"-"
-                        !partition.precomputing_done -> +"Computing size..."
+                        !partition.precomputing_done -> +"Computing..."
                         partition.matching_records_per_minute == null ||
                           partition.matching_records_per_minute <= 0 -> +"Calculating..."
                         else -> +"""${partition.matching_records_per_minute} #/m"""

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
@@ -177,7 +177,15 @@ class BackfillShowAction @Inject constructor(
                         partition.computed_matching_record_count,
                       )
                     }
-                    td("hidden py-5 pl-8 pr-0 text-right align-top tabular-nums text-gray-700 sm:table-cell") { +"""${partition.matching_records_per_minute} #/m""" }
+                    td("hidden py-5 pl-8 pr-0 text-right align-top tabular-nums text-gray-700 sm:table-cell") {
+                      when {
+                        partition.state != BackfillState.RUNNING -> +"-"
+                        !partition.precomputing_done -> +"Computing size..."
+                        partition.matching_records_per_minute == null ||
+                          partition.matching_records_per_minute <= 0 -> +"Calculating..."
+                        else -> +"""${partition.matching_records_per_minute} #/m"""
+                      }
+                    }
                     // TODO properly calculate the ETA until finished
                     td("py-5 pl-8 pr-0 text-right align-top tabular-nums text-gray-700") { +"""ETA TODO""" }
                   }


### PR DESCRIPTION
When precomputing
![Screenshot 2025-04-21 at 9 14 25 PM](https://github.com/user-attachments/assets/a8b35f70-1530-4160-ad75-8af88e5e25f4)

When precomputing is done, but no rate to provide
![Screenshot 2025-04-21 at 8 55 17 PM](https://github.com/user-attachments/assets/71d9a9ea-aadf-429f-a3f2-9d51fb278197)

When in running state
![Screenshot 2025-04-21 at 8 55 37 PM](https://github.com/user-attachments/assets/0bea4c3c-fd25-40c1-b6a9-1922114c9afc)

When complete
![Screenshot 2025-04-21 at 8 55 47 PM](https://github.com/user-attachments/assets/5e9d2bc9-06c0-4369-bda2-153cec041141)




Empty State Messages:
- "Computing size..." when precomputing isn't done
- "-" when not in RUNNING state
- "Calculating..." when we don't have enough data to calculate ETA