### PR TITLE
Add ApiCallTimeoutException handling to UpdateInPlaceDynamoDbBackfill

### DIFF
--- a/client-dynamodb-v2/src/main/kotlin/app/cash/backfila/client/dynamodbv2/UpdateInPlaceDynamoDbBackfill.kt
+++ b/client-dynamodb-v2/src/main/kotlin/app/cash/backfila/client/dynamodbv2/UpdateInPlaceDynamoDbBackfill.kt
@@ -1,6 +1,7 @@
 package app.cash.backfila.client.dynamodbv2
 
 import app.cash.backfila.client.BackfillConfig
+import software.amazon.awssdk.core.exception.ApiCallTimeoutException
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse
@@ -12,9 +13,14 @@ import kotlin.math.pow
 /**
  * A base class that may make it easier to mutate the items in the DynamoDB store.
  *
- * Implements retry logic with exponential backoff for unprocessed items from BatchWriteItem operations.
- * Failed items from all batches are collected and retried together to optimize throughput.
- * The retry counter only starts when we stop making progress (no items processed in a round).
+ * Implements retry logic with exponential backoff for:
+ * - Unprocessed items from BatchWriteItem operations
+ * - API timeouts
+ * 
+ * The retry counter for unprocessed items only starts when we stop making progress 
+ * (no items processed in a round). The timeout counter only increments when all chunks
+ * in an iteration timeout.
+ * 
  * Implementations must be idempotent as items may be retried multiple times.
  */
 abstract class UpdateInPlaceDynamoDbBackfill<I : Any, P : Any>(
@@ -36,12 +42,14 @@ abstract class UpdateInPlaceDynamoDbBackfill<I : Any, P : Any>(
     if (itemsToSave.isNotEmpty()) {
       var unprocessedItems = itemsToSave
       var stuckRetryCount = 0
+      var consecutiveTimeouts = 0
       var totalAttempts = 0
 
       while (unprocessedItems.isNotEmpty()) {
         if (totalAttempts > 0) {
           // Calculate backoff time with exponential increase and jitter
-          val backoffAttempts = stuckRetryCount.coerceAtLeast(1) // Use at least 1 for backoff calc
+          // Use the larger of stuckRetryCount or consecutiveTimeouts to determine backoff
+          val backoffAttempts = maxOf(stuckRetryCount, consecutiveTimeouts).coerceAtLeast(1)
           val baseWait = min(
             MAX_BACKOFF_MS.toDouble(),
             BASE_BACKOFF_MS * 2.0.pow(backoffAttempts.toDouble())
@@ -52,21 +60,62 @@ abstract class UpdateInPlaceDynamoDbBackfill<I : Any, P : Any>(
 
         // Process all items in BATCH_SIZE_LIMIT chunks, collect all unprocessed
         val stillUnprocessed = mutableListOf<I>()
+        var batchSucceeded = false
+        var lastTimeoutException: ApiCallTimeoutException? = null
+        var hadTimeoutThisIteration = false
+        var allChunksTimedOut = true
         
         unprocessedItems.chunked(BATCH_SIZE_LIMIT).forEach { chunk ->
-          val writeRequests = createWriteRequests(chunk)
-          val batchRequest = BatchWriteItemRequest.builder()
-            .requestItems(mapOf(dynamoDbTable.tableName() to writeRequests))
-            .build()
+          try {
+            val writeRequests = createWriteRequests(chunk)
+            val batchRequest = BatchWriteItemRequest.builder()
+              .requestItems(mapOf(dynamoDbTable.tableName() to writeRequests))
+              .build()
 
-          val response = dynamoDbClient.batchWriteItem(batchRequest)
-          stillUnprocessed.addAll(getUnprocessedItems(response))
+            val response = dynamoDbClient.batchWriteItem(batchRequest)
+            stillUnprocessed.addAll(getUnprocessedItems(response))
+            batchSucceeded = true
+            allChunksTimedOut = false
+          } catch (e: ApiCallTimeoutException) {
+            // On timeout, only add the current chunk to unprocessed items
+            stillUnprocessed.addAll(chunk)
+            hadTimeoutThisIteration = true
+            lastTimeoutException = e
+          }
+        }
+
+        // Handle timeout tracking
+        if (hadTimeoutThisIteration && allChunksTimedOut) {
+          consecutiveTimeouts++
+          if (consecutiveTimeouts >= MAX_RETRY_ATTEMPTS) {
+            throw DynamoDbBatchWriteException(
+              """Failed due to consecutive complete timeouts after $MAX_RETRY_ATTEMPTS attempts.
+                 |Total attempts: $totalAttempts
+                 |Initial batch size: ${itemsToSave.size}
+                 |Remaining unprocessed items: ${unprocessedItems.size}""".trimMargin(),
+              lastTimeoutException
+            )
+          }
+        } else if (batchSucceeded) {
+          // Reset timeout counter if any chunk succeeded
+          consecutiveTimeouts = 0
+        }
+        
+        // If we saw any timeouts but didn't hit the consecutive limit, include the last exception
+        // as suppressed to maintain error context
+        if (lastTimeoutException != null && !allChunksTimedOut) {
+          lastTimeoutException!!.addSuppressed(
+            IllegalStateException(
+              """Saw partial timeouts while processing batches.
+                 |Successfully processed some chunks, continuing with retries.""".trimMargin()
+            )
+          )
         }
 
         totalAttempts++
         
-        // Check if we made any progress
-        if (stillUnprocessed.size == unprocessedItems.size) {
+        // Check if we made any progress with unprocessed items
+        if (batchSucceeded && stillUnprocessed.size == unprocessedItems.size) {
           // No progress made, increment stuck counter
           stuckRetryCount++
           if (stuckRetryCount >= MAX_RETRY_ATTEMPTS) {
@@ -77,8 +126,8 @@ abstract class UpdateInPlaceDynamoDbBackfill<I : Any, P : Any>(
                  |Remaining unprocessed items: ${stillUnprocessed.size}""".trimMargin()
             )
           }
-        } else {
-          // Made some progress, reset stuck counter
+        } else if (batchSucceeded) {
+          // Made some progress or had different number of unprocessed items
           stuckRetryCount = 0
         }
 
@@ -121,4 +170,4 @@ abstract class UpdateInPlaceDynamoDbBackfill<I : Any, P : Any>(
   abstract fun runOne(item: I, config: BackfillConfig<P>): Boolean
 }
 
-class DynamoDbBatchWriteException(message: String) : RuntimeException(message)
+class DynamoDbBatchWriteException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)


### PR DESCRIPTION
## Problem

The DynamoDB BatchWriteItem implementation in UpdateInPlaceDynamoDbBackfill currently lacks handling for ApiCallTimeoutException. When these timeouts occur, the entire batch fails without any retry attempts, causing backfills to fail unnecessarily.

## Solution

Add comprehensive timeout handling with these features:
- Track and retry chunks that experience API timeouts
- Use exponential backoff with jitter for retries
- Only increment the timeout counter when all chunks in an iteration timeout
- Reset the timeout counter if any chunk succeeds
- Maintain separate counters for timeouts vs unprocessed items
- Provide detailed error context through suppressed exceptions

The implementation is designed to be resilient to transient timeouts while still protecting against systemic failures. It coordinates the backoff strategy between timeout retries and unprocessed item retries.