### PR TITLE
enable non numerical values for range

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
@@ -262,7 +262,7 @@ class BackfillCreateAction @Inject constructor(
                                   input(
                                     classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6",
                                   ) {
-                                    type = InputType.number
+                                    type = InputType.text
                                     name = field
                                     id = field
                                     attributes["autocomplete"] = field
@@ -279,7 +279,7 @@ class BackfillCreateAction @Inject constructor(
                                   input(
                                     classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6",
                                   ) {
-                                    type = InputType.number
+                                    type = InputType.text
                                     name = field
                                     id = field
                                     attributes["autocomplete"] = field
@@ -302,7 +302,7 @@ class BackfillCreateAction @Inject constructor(
                         }
                         div("mt-2") {
                           input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
-                            type = InputType.number
+                            type = InputType.text
                             name = field
                             id = field
                             attributes["autocomplete"] = field
@@ -317,7 +317,7 @@ class BackfillCreateAction @Inject constructor(
                         }
                         div("mt-2") {
                           input(classes = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6") {
-                            type = InputType.number
+                            type = InputType.text
                             name = field
                             id = field
                             attributes["autocomplete"] = field


### PR DESCRIPTION
The changes involve modifications to the range-handling logic, allowing Backfila to process start and end range to be non-numeric values.

This change addresses a discussion raised in [Slack](https://cash.slack.com/archives/C0151JAREE7/p1746490372275049). The backfill at [Backfila #17385](https://backfila.stage.sqprod.co/backfills/17385) uses Jooq backfills. Depending on the specific type of backfill, we want to support non-numerical range values and delegate range validation to the corresponding backfill operator. For instance, the StaticDatasourceBackfillOperator will enforce that ranges are numerical.

Will save this for Mike to review
