### PR TITLE
Migrate to Sonatype Central Portal

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -64,9 +64,10 @@ jobs:
     needs: [js, jvm]
     runs-on: ubuntu-latest
     env:
-      ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-      ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-      ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
+      ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}
+      ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_CENTRAL_PASSWORD }}
+      ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SECRET_PASSPHRASE }}
 
     steps:
       - name: Checkout

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,7 +133,7 @@ allprojects {
       }
     }
     configure<MavenPublishBaseExtension> {
-      publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
+      publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
       signAllPublications()
       pom {
         description.set("Backfila is a service that manages backfill state, calling into other services to do batched work.")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ junitEngine = { module = "org.junit.jupiter:junit-jupiter-engine", version = "5.
 junitParams = { module = "org.junit.jupiter:junit-jupiter-params", version = "5.9.1" }
 logbackClassic = { module = "ch.qos.logback:logback-classic", version = "1.4.11" }
 loggingApi = { module = "io.github.microutils:kotlin-logging", version = "2.1.23" }
-mavenPublishGradlePlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.25.2" }
+mavenPublishGradlePlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.31.0" }
 metricsCore = { module = "io.dropwizard.metrics:metrics-core", version = "4.0.2" }
 metricsParent = { module = "io.dropwizard.metrics:metrics-parent", version = "4.0.2" }
 moshiCore = { module = "com.squareup.moshi:moshi", version = "1.13.0" }


### PR DESCRIPTION
See (internally) http://go/central-portal-migration-app-cash for context.