### PR TITLE
Add last registered at column to Services

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/api/ConfigureServiceAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/api/ConfigureServiceAction.kt
@@ -68,6 +68,7 @@ class ConfigureServiceAction @Inject constructor(
           request.connector_extra_data,
           request.slack_channel,
           variant,
+          clock.instant(),
         )
         session.save(dbService)
       } else {
@@ -75,6 +76,7 @@ class ConfigureServiceAction @Inject constructor(
         dbService.connector_extra_data = request.connector_extra_data
         dbService.slack_channel = request.slack_channel
         dbService.variant = variant
+        dbService.last_registered_at = clock.instant()
       }
 
       // Add any missing backfills, update modified ones, and mark missing ones as deleted.

--- a/service/src/main/kotlin/app/cash/backfila/service/persistence/DbService.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/persistence/DbService.kt
@@ -37,17 +37,22 @@ class DbService() : DbUnsharded<DbService>, DbTimestampedEntity {
   @Column
   override lateinit var updated_at: Instant
 
+  @Column(nullable = true)
+  var last_registered_at: Instant? = null
+
   constructor(
     registry_name: String,
     connector: String,
     connector_extra_data: String?,
     slack_channel: String?,
     variant: String,
+    last_registered_at: Instant?,
   ) : this() {
     this.registry_name = registry_name
     this.connector = connector
     this.connector_extra_data = connector_extra_data
     this.slack_channel = slack_channel
     this.variant = variant
+    this.last_registered_at = last_registered_at
   }
 }

--- a/service/src/main/resources/migrations/v020__backfila.sql
+++ b/service/src/main/resources/migrations/v020__backfila.sql
@@ -1,0 +1,2 @@
+ALTER TABLE services
+ADD COLUMN last_registered_at timestamp NULL;

--- a/service/src/main/resources/migrations/v020__backfila.sql
+++ b/service/src/main/resources/migrations/v020__backfila.sql
@@ -1,2 +1,2 @@
 ALTER TABLE services
-ADD COLUMN last_registered_at timestamp NULL;
+ADD COLUMN last_registered_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3);


### PR DESCRIPTION
We're adding a new last_registered_at column to the services table. This is similar to the updated_at column in registered_backfills, but instead of tracking only config changes, it will also update whenever the service is re-registered.
This column will be used in our deprecation reminder. 

When reregistered
![Screenshot 2025-05-14 at 3 27 40 PM](https://github.com/user-attachments/assets/bff3e475-2640-434f-af36-5e16b95af61e)

When registered
![Screenshot 2025-05-14 at 3 27 17 PM](https://github.com/user-attachments/assets/15828ba5-a837-4807-b121-474df8a85fa4)
