### PR TITLE
Reset consecutive failure count on range success

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/service/runner/statemachine/BatchAwaiter.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/runner/statemachine/BatchAwaiter.kt
@@ -75,6 +75,10 @@ class BatchAwaiter(
           }
 
           if (response.remaining_batch_range != null) {
+            // A successfully processed range within a batch counts as a successful RPC for the
+            // purposes of resetting the count of consecutive failures.
+            backfillRunner.onRpcSuccess()
+
             // We have a remaining_batch_range, continue the batch.
             remainingBatch = initialBatch.newBuilder()
               .batch_range(response.remaining_batch_range)


### PR DESCRIPTION
Currently, the count of consecutive failures is only reset when a batch is fully completed. This can be problematic if the sizes of batches are imbalanced and some batches are very large, where a single batch can contain many ranges that need to be processed. Normally when batches encounter transient failures, the count is reset when the batch is eventually processed and the backfill moves on - if, however, for a large enough batch, enough transient failures are encountered for ranges within that batch, the entire backfill will fail. This change resets the count of consecutive failures when a range within a batch is processed so backfills do not get stuck when this occurs.