### PR TITLE
Adjust rate logic to render even in precomputing stage

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
@@ -194,8 +194,7 @@ class BackfillShowAction @Inject constructor(
                         partition.state != BackfillState.RUNNING -> +"-"
                         partition.matching_records_per_minute == null ||
                           partition.matching_records_per_minute <= 0 -> {
-                            if (!partition.precomputing_done) +"Computing..."
-                            else +"Calculating..."
+                          if (!partition.precomputing_done) { +"Computing..." } else { +"Calculating..." }
                         }
                         else -> +"""${partition.matching_records_per_minute} #/m"""
                       }

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
@@ -194,8 +194,8 @@ class BackfillShowAction @Inject constructor(
                         partition.state != BackfillState.RUNNING -> +"-"
                         partition.matching_records_per_minute == null ||
                           partition.matching_records_per_minute <= 0 -> {
-                          if (!partition.precomputing_done) +"Computing..."
-                          else +"Calculating..."
+                            if (!partition.precomputing_done) +"Computing..."
+                            else +"Calculating..."
                         }
                         else -> +"""${partition.matching_records_per_minute} #/m"""
                       }

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
@@ -192,9 +192,11 @@ class BackfillShowAction @Inject constructor(
                     td("hidden py-5 pl-8 pr-0 text-right align-top tabular-nums text-gray-700 sm:table-cell") {
                       when {
                         partition.state != BackfillState.RUNNING -> +"-"
-                        !partition.precomputing_done -> +"Computing..."
                         partition.matching_records_per_minute == null ||
-                          partition.matching_records_per_minute <= 0 -> +"Calculating..."
+                          partition.matching_records_per_minute <= 0 -> {
+                          if (!partition.precomputing_done) +"Computing..."
+                          else +"Calculating..."
+                        }
                         else -> +"""${partition.matching_records_per_minute} #/m"""
                       }
                     }

--- a/service/src/test/kotlin/app/cash/backfila/ui/components/DashboardPageLayoutTest.kt
+++ b/service/src/test/kotlin/app/cash/backfila/ui/components/DashboardPageLayoutTest.kt
@@ -3,6 +3,9 @@ package app.cash.backfila.ui.components
 import app.cash.backfila.BackfilaTestingModule
 import com.google.inject.Provider
 import jakarta.inject.Inject
+import javax.servlet.http.HttpServletRequest
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import misk.Action
 import misk.MiskCaller
 import misk.api.HttpRequest
@@ -19,9 +22,6 @@ import misk.web.dashboard.BaseDashboardModule
 import misk.web.v2.DashboardPageLayout
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.jupiter.api.Test
-import javax.servlet.http.HttpServletRequest
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
 @MiskTest
 class DashboardPageLayoutTest {
@@ -42,8 +42,8 @@ class DashboardPageLayoutTest {
     actionScope.enter(
       mapOf(
         HttpCall::class.toKey() to fakeHttpCall,
-        MiskCaller::class.toKey() to fakeMiskCaller
-      )
+        MiskCaller::class.toKey() to fakeMiskCaller,
+      ),
     ).use {
       // No exception thrown on correct usage
       layout.get().newBuilder().build()


### PR DESCRIPTION
Fix a discrepancy in how backfill rates are displayed between the old and new UI implementations.

## Issue
The new UI was incorrectly hiding valid rate information during precomputing phase. For example:
- Old UI: Shows "300 #/m" (correct)
- New UI: Shows "Computing..." (incorrect when we have a valid rate)
- When the pre-computation is done, the rate matches with the old UI
## Changes
Modified the rate display logic in BackfillShowAction.kt to:
1. Show actual rates when available, even during precomputing
2. Only show "Computing..." when there's no rate during precomputing
3. Show "Calculating..." when there's no rate after precomputing is done


https://backfila.sqprod.co/backfills/29757
Old UI renders rate 
![Screenshot 2025-05-21 at 1 22 02 PM](https://github.com/user-attachments/assets/ee61ce5c-805e-4d44-880c-d182f76bae43)

New UI Does not
![Screenshot 2025-05-21 at 1 21 58 PM](https://github.com/user-attachments/assets/faa00cae-d458-4f31-8da8-8d73120f2e48)
