### PR TITLE
Make unit default to null

### DIFF
--- a/client-base/src/main/kotlin/app/cash/backfila/client/spi/BackfillRegistration.kt
+++ b/client-base/src/main/kotlin/app/cash/backfila/client/spi/BackfillRegistration.kt
@@ -8,5 +8,5 @@ data class BackfillRegistration(
   val description: String?,
   val parametersClass: KClass<Any>,
   val deleteBy: Instant?,
-  val unit: String?,
+  val unit: String? = null,
 )


### PR DESCRIPTION
Modified the `unit` field to be nullable, allowing existing backfills to continue working without requiring a unit value. This maintains backward compatibility while still supporting the new unit display feature for backfills that specify it.
