### PR TITLE
Add JvmOverloads to BackfillRegistration for binary compatibility

### DIFF
--- a/client-base/src/main/kotlin/app/cash/backfila/client/spi/BackfillRegistration.kt
+++ b/client-base/src/main/kotlin/app/cash/backfila/client/spi/BackfillRegistration.kt
@@ -3,7 +3,7 @@ package app.cash.backfila.client.spi
 import java.time.Instant
 import kotlin.reflect.KClass
 
-data class BackfillRegistration(
+data class BackfillRegistration @JvmOverloads constructor(
   val name: String,
   val description: String?,
   val parametersClass: KClass<Any>,


### PR DESCRIPTION
The addition of the `unit` argument recently is leading to `NoSuchMethodError`s where code is compiled against an old versio of backfila without this argument, but a new version is present at runtime with the argument. This might fix it by adding overloaded methods (although, I'm not entirely sure whether the new code will be compatible with the code compiled against the method without the JvmOverloads annotation), but it'll at least prevent similar errors in future. 