### PR TITLE
Move the state information above the configuration section

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/ui/actions/BackfillShowButtonHandlerAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/actions/BackfillShowButtonHandlerAction.kt
@@ -127,13 +127,13 @@ class BackfillShowButtonHandlerAction @Inject constructor(
     val frameContent = dashboardPageLayout.newBuilder()
       .buildHtmlResponseBody {
         turbo_frame("backfill-$id-state") {
-          div("flex flex-col items-end gap-2") {
+          div("flex items-start gap-3") {
+            div("flex flex-col") {
+              renderStateButtons(id, currentState)
+            }
             div("flex items-center gap-2") {
               span("text-sm font-medium text-gray-500") { +"State:" }
               span("text-sm font-semibold text-gray-900") { +currentState.name }
-            }
-            div("flex items-center gap-2") {
-              renderStateButtons(id, currentState)
             }
           }
         }
@@ -159,7 +159,7 @@ class BackfillShowButtonHandlerAction @Inject constructor(
   }
 
   fun TagConsumer<*>.renderButton(id: String, fieldId: String, button: Link, color: String) {
-    form {
+    form(classes = "m-0 pb-1") {
       action = path(id)
       input {
         type = InputType.hidden

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
@@ -90,7 +90,7 @@ class BackfillShowAction @Inject constructor(
       .buildHtmlResponseBody {
         // Configuration section - outside AutoReload
         PageTitle("${backfill.service_name} Backfill Run", "#$id", backfill.name) {
-          div("flex items-center gap-6") {
+          div("flex items-start gap-3") {
             a {
               href = BackfillCreateAction.path(
                 service = backfill.service_name,
@@ -107,15 +107,15 @@ class BackfillShowAction @Inject constructor(
             // State section with its own auto-reload
             AutoReload(frameId = "backfill-$id-state") {
               turbo_frame("backfill-$id-state") {
-                div("flex flex-col items-end gap-2") {
-                  div("flex items-center gap-2") {
-                    span("text-sm font-bold text-gray-500") { +"State:" }
-                    span("text-sm font-semibold text-gray-900") { +backfill.state.name }
-                  }
-                  div("flex items-center gap-2") {
+                div("flex items-start gap-2") {
+                  div("flex flex-col") {
                     with(backfillShowButtonHandlerAction) {
                       renderStateButtons(id.toString(), backfill.state, backfill.deleted_at)
                     }
+                  }
+                  div("flex items-center gap-2") {
+                    span("text-sm font-bold text-gray-500") { +"State:" }
+                    span("text-sm font-semibold text-gray-900") { +backfill.state.name }
                   }
                 }
               }


### PR DESCRIPTION
Refactored the BackfillShowAction UI layout to move the state information above the configuration section and improve the visual alignment of the Clone button and State section with the page title.

Test that the turbo frame works as expected




https://github.com/user-attachments/assets/82e8bbd4-2bb6-4bef-a3ba-9cc191f308e5


