### PR TITLE
Fix dry run cloning error

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
@@ -171,18 +171,8 @@ class BackfillCreateAction @Inject constructor(
                               attributes["aria-describedby"] = "dry-run-description"
                               name = field
                               type = InputType.checkBox
-                              // Checked by default to force user to opt-in to non-dry-run
-                              checked = true
-                              placeholder = "on"
-                              backfillToCloneStatus?.let {
-                                if (it.dry_run) {
-                                  value = "on"
-                                  checked = true
-                                } else {
-                                  value = "off"
-                                  checked = false
-                                }
-                              }
+                              // Set checkbox state based on cloned backfill or default to checked
+                              checked = backfillToCloneStatus?.dry_run ?: true
                             }
                           }
                         }


### PR DESCRIPTION
When cloning a wet run backfill and checking the "dry run" checkbox in the new UI, the cloned backfill was not actually created as a dry run. The checkbox state change was not being properly reflected in the resulting backfill.

https://github.com/user-attachments/assets/600e02e3-664e-439c-a90a-ff863b5122d9


