### PR TITLE
add target exclude directories for kotlin spotless checks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,13 @@ subprojects {
   configure<SpotlessExtension> {
     kotlin {
       target("**/*.kt")
+      targetExclude(
+          "**/node_modules/**", 
+          "**/build/**", 
+          "**/.gradle/**",
+          "web/**",
+          "**/web/**"
+      )
       ktlint(libs.versions.ktlint.get()).editorConfigOverride(
           mapOf(
               "indent_size" to "2",


### PR DESCRIPTION
Publish step is failing on github. We want to exclude certain directories from kotlin spotless checks

"""
https://github.com/cashapp/backfila/actions/runs/16151642104/job/45584471457
> Task :service:spotlessKotlin FAILED
Error on line: 22, column: 1
rule: no-wildcard-imports
Wildcard import
java.lang.AssertionError: Error on line: 22, column: 1
rule: no-wildcard-imports
Wildcard import
	at com.diffplug.spotless.glue.ktlint.compat.KtLintCompatReporting.report(KtLintCompatReporting.java:23)
	at com.diffplug.spotless.glue.ktlint.compat.KtLintCompat0Dot47Dot0Adapter$FormatterCallback.invoke(KtLintCompat0Dot47Dot0Adapter.java:50)
	at com.diffplug.spotless.glue.ktlint.compat.KtLintCompat0Dot47Dot0Adapter$FormatterCallback.invoke(KtLintCompat0Dot47Dot0Adapter.java:46)
	at com.pinterest.ktlint.core.KtLint.format(KtLint.kt:300)
	at com.diffplug.spotless.glue.ktlint.compat.KtLintCompat0Dot47Dot0Adapter.format(KtLintCompat0Dot47Dot0Adapter.java:79)
	at com.diffplug.spotless.glue.ktlint.KtlintFormatterFunc.applyWithFile(KtlintFormatterFunc.java:71)
	at com.diffplug.spotless.FormatterFunc$NeedsFile.apply(FormatterFunc.java:154)
	at com.diffplug.spotless.FormatterStepImpl$Standard.format(FormatterStepImpl.java:82)
	at com.diffplug.spotless.FormatterStep$Strict.format(FormatterStep.java:88)
	at com.diffplug.spotless.Formatter.compute(Formatter.java:230)
	at com.diffplug.spotless.PaddedCell.calculateDirtyState(PaddedCell.java:203)
	at com.diffplug.spotless.PaddedCell.calculateDirtyState(PaddedCell.java:190)
	at com.diffplug.gradle.spotless.SpotlessTaskImpl.processInputFile(SpotlessTaskImpl.java:102)
	at com.diffplug.gradle.spotless.SpotlessTaskImpl.performAction(SpotlessTaskImpl.java:88)
	at jdk.internal.reflect.GeneratedMethodAccessor657.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:125)
	at org.gradle.api.internal.project.taskfactory.IncrementalTaskAction.doExecute(IncrementalTaskAction.java:45)
	at org.gradle.api.internal.project.taskfactory.StandardTaskAction.execute(StandardTaskAction.java:51)
	at org.gradle.api.internal.project.taskfactory.IncrementalTaskAction.execute(IncrementalTaskAction.java:26)
	at org.gradle.api.internal.project.taskfactory.StandardTaskAction.execute(StandardTaskAction.java:29)
	at org.gradle.api.internal.tasks.execution.TaskExecution$3.run(TaskExecution.java:244)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:29)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:26)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:166)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
"""