### PR TITLE
Update the timestamps to clients local time

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/ui/components/DashboardPageLayout.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/components/DashboardPageLayout.kt
@@ -112,6 +112,8 @@ class DashboardPageLayout @Inject constructor(
             type = "module"
             src = "/static/js/search_bar_controller.js"
           }
+          // Include any custom head block content
+          headBlock()
         },
       ) {
         div("min-h-full") {

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
@@ -28,6 +28,7 @@ import kotlinx.html.form
 import kotlinx.html.h2
 import kotlinx.html.input
 import kotlinx.html.pre
+import kotlinx.html.script
 import kotlinx.html.span
 import kotlinx.html.table
 import kotlinx.html.tbody
@@ -76,6 +77,12 @@ class BackfillShowAction @Inject constructor(
 
     val htmlResponseBody = dashboardPageLayout.newBuilder()
       .title("Backfill $id | Backfila")
+      .headBlock {
+        // Add JavaScript to format timestamps in user's timezone
+        script {
+          +formatTimestampsScript()
+        }
+      }
       .breadcrumbLinks(
         Link("Services", ServiceIndexAction.PATH),
         Link(
@@ -131,7 +138,7 @@ class BackfillShowAction @Inject constructor(
               h2("text-base font-semibold leading-6 text-gray-900") { +"""Configuration""" }
               dl("divide-y divide-gray-100") {
                 leftColumnConfigurationRows.map {
-                  ConfigurationRows(id, it)
+                  ConfigurationRows(id, it, backfill)
                 }
               }
             }
@@ -140,7 +147,7 @@ class BackfillShowAction @Inject constructor(
             div("divide-x divide-gray-100") {
               dl("divide-y divide-gray-100") {
                 rightColumnConfigurationRows.map {
-                  ConfigurationRows(id, it)
+                  ConfigurationRows(id, it, backfill)
                 }
               }
             }
@@ -345,7 +352,13 @@ class BackfillShowAction @Inject constructor(
                   backfill.event_logs.map { log ->
                     tr("border-b border-gray-100") {
                       td("hidden py-5 pl-8 pr-0 align-top text-wrap text-gray-700 sm:table-cell") {
-                        +log.occurred_at.toString().replace("T", " ").dropLast(5)
+                        // Use a data attribute to store the ISO timestamp and let JavaScript format it
+                        span {
+                          attributes["data-timestamp"] = log.occurred_at.toString()
+                          attributes["class"] = "localized-time"
+                          // Fallback display (will be replaced by JavaScript)
+                          +log.occurred_at.toString().replace("T", " ").dropLast(5)
+                        }
                       }
                       td("hidden py-5 pl-8 pr-0 align-top text-gray-700 sm:table-cell") { log.user?.let { +it } }
                       td("hidden py-5 pl-8 pr-0 align-top text-gray-700 sm:table-cell") { log.partition_name?.let { +it } }
@@ -466,7 +479,7 @@ class BackfillShowAction @Inject constructor(
     ),
     DescriptionListRow(
       label = "Created",
-      description = "$created_at by $created_by_user",
+      description = "by $created_by_user",
     ),
     DescriptionListRow(
       label = "Logs",
@@ -499,7 +512,7 @@ class BackfillShowAction @Inject constructor(
     }
   }
 
-  private fun TagConsumer<*>.ConfigurationRows(id: Long, it: DescriptionListRow) {
+  private fun TagConsumer<*>.ConfigurationRows(id: Long, it: DescriptionListRow, backfill: GetBackfillStatusResponse) {
     div("px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0") {
       attributes["data-controller"] = "toggle"
 
@@ -509,7 +522,18 @@ class BackfillShowAction @Inject constructor(
           attributes["data-toggle-target"] = "toggleable"
           attributes["data-css-class"] = "hidden"
 
-          +it.description
+          // Special handling for "Created" field to add timestamp formatting
+          if (it.label == "Created") {
+            span {
+              attributes["data-timestamp"] = backfill.created_at.toString()
+              attributes["class"] = "localized-time"
+              // Fallback display (will be replaced by JavaScript)
+              +backfill.created_at.toString().replace("T", " ").dropLast(5)
+            }
+            +" ${it.description}"
+          } else {
+            +it.description
+          }
         }
         it.button?.let { button ->
           if (button.label == UPDATE_BUTTON_LABEL) {
@@ -721,6 +745,69 @@ class BackfillShowAction @Inject constructor(
 
     return if (sb.isEmpty()) "< 1s" else sb.toString()
   }
+
+  private fun formatTimestampsScript(): String = """
+    function formatTimestamps() {
+      document.querySelectorAll('.localized-time').forEach(function(element) {
+        const timestamp = element.getAttribute('data-timestamp');
+        if (timestamp) {
+          try {
+            const date = new Date(timestamp);
+            
+            if (!isNaN(date.getTime())) {
+              let formatted;
+              try {
+                // First try with en-CA locale (same as old UI)
+                formatted = date.toLocaleString('en-CA', {
+                  timeZoneName: 'short',
+                  year: 'numeric',
+                  month: '2-digit',
+                  day: '2-digit',
+                  hour: '2-digit',
+                  minute: '2-digit',
+                  second: '2-digit',
+                  hour12: true
+                });
+              } catch (e1) {
+                // Fallback to default locale
+                formatted = date.toLocaleString(undefined, {
+                  timeZoneName: 'short',
+                  year: 'numeric',
+                  month: '2-digit',
+                  day: '2-digit',
+                  hour: '2-digit',
+                  minute: '2-digit',
+                  second: '2-digit',
+                  hour12: true
+                });
+              }
+              
+              // Clean up the formatting to match old UI
+              formatted = formatted.replace(',', '').replace(/\.m\./g, 'm');
+              element.textContent = formatted;
+            }
+          } catch (e) {
+            console.error('Failed to format timestamp:', timestamp, e);
+          }
+        }
+      });
+    }
+    
+    // Run immediately when script loads
+    formatTimestamps();
+    
+    // Run on initial page load
+    document.addEventListener('DOMContentLoaded', formatTimestamps);
+    
+    // Also run after turbo frame loads (for auto-reload)
+    document.addEventListener('turbo:frame-load', formatTimestamps);
+    
+    // Run after a short delay to ensure everything is loaded
+    setTimeout(formatTimestamps, 100);
+    
+    // Run periodically to catch any missed updates
+    setInterval(formatTimestamps, 1000);
+  """.trimIndent()
 
   companion object {
     private const val PATH = "/backfills/{id}"

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
@@ -80,7 +80,7 @@ class BackfillShowAction @Inject constructor(
       .headBlock {
         // Add JavaScript to format timestamps in user's timezone
         script {
-          +formatTimestampsScript()
+          +formatToLocalTimestampsScript()
         }
       }
       .breadcrumbLinks(
@@ -355,7 +355,6 @@ class BackfillShowAction @Inject constructor(
                         span {
                           attributes["data-timestamp"] = log.occurred_at.toString()
                           attributes["class"] = "localized-time"
-                          // Fallback display (will be replaced by JavaScript)
                           +log.occurred_at.toString().replace("T", " ").dropLast(5)
                         }
                       }
@@ -526,7 +525,6 @@ class BackfillShowAction @Inject constructor(
             span {
               attributes["data-timestamp"] = backfill.created_at.toString()
               attributes["class"] = "localized-time"
-              // Fallback display (will be replaced by JavaScript)
               +backfill.created_at.toString().replace("T", " ").dropLast(5)
             }
             +" ${it.description}"
@@ -745,7 +743,7 @@ class BackfillShowAction @Inject constructor(
     return if (sb.isEmpty()) "< 1s" else sb.toString()
   }
 
-  private fun formatTimestampsScript(): String = """
+  private fun formatToLocalTimestampsScript(): String = """
     function formatTimestamps() {
       document.querySelectorAll('.localized-time').forEach(function(element) {
         const timestamp = element.getAttribute('data-timestamp');

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
@@ -352,7 +352,6 @@ class BackfillShowAction @Inject constructor(
                   backfill.event_logs.map { log ->
                     tr("border-b border-gray-100") {
                       td("hidden py-5 pl-8 pr-0 align-top text-wrap text-gray-700 sm:table-cell") {
-                        // Use a data attribute to store the ISO timestamp and let JavaScript format it
                         span {
                           attributes["data-timestamp"] = log.occurred_at.toString()
                           attributes["class"] = "localized-time"
@@ -757,7 +756,6 @@ class BackfillShowAction @Inject constructor(
             if (!isNaN(date.getTime())) {
               let formatted;
               try {
-                // First try with en-CA locale (same as old UI)
                 formatted = date.toLocaleString('en-CA', {
                   timeZoneName: 'short',
                   year: 'numeric',
@@ -781,8 +779,7 @@ class BackfillShowAction @Inject constructor(
                   hour12: true
                 });
               }
-              
-              // Clean up the formatting to match old UI
+
               formatted = formatted.replace(',', '').replace(/\.m\./g, 'm');
               element.textContent = formatted;
             }
@@ -793,16 +790,10 @@ class BackfillShowAction @Inject constructor(
       });
     }
     
-    // Run immediately when script loads
     formatTimestamps();
-    
-    // Run on initial page load
+
     document.addEventListener('DOMContentLoaded', formatTimestamps);
-    
-    // Also run after turbo frame loads (for auto-reload)
     document.addEventListener('turbo:frame-load', formatTimestamps);
-    
-    // Run after a short delay to ensure everything is loaded
     setTimeout(formatTimestamps, 100);
     
     // Run periodically to catch any missed updates


### PR DESCRIPTION
Backfila currently displays all timestamps in UTC format (e.g., 2025-06-10 03:00:57)

This pr convert UTC timestamps to the user's local timezone with a more readable format including AM/PM and timezone abbreviation.

Before: 2025-06-10 03:00:57 (UTC, unclear timezone)
After: 06/10/2025 11:00:57 PM EDT (localized with timezone info)


<img width="1224" height="397" alt="Screenshot 2025-07-18 at 6 07 43 PM" src="https://github.com/user-attachments/assets/cad0a8f2-0310-4058-b18f-34cf371b74df" />

<img width="804" height="419" alt="Screenshot 2025-07-18 at 6 07 39 PM" src="https://github.com/user-attachments/assets/f9ccd53f-f7e9-4989-8ecc-350d6b107670" />


