### PR TITLE
Use full width of the page rather than limited

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/ui/components/DashboardPageLayout.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/components/DashboardPageLayout.kt
@@ -127,8 +127,8 @@ class DashboardPageLayout @Inject constructor(
           ) {
             div("py-10") {
               main {
-                // TODO maybe make max-w wider
-                div("mx-auto max-w-7xl sm:px-6 lg:px-8") {
+                // Use full width for better table display
+                div("mx-auto max-w-full px-4 sm:px-6 lg:px-8") {
                   // TODO remove when new UI is stable and preferred
                   UseOldUIAlert()
 

--- a/service/src/main/kotlin/app/cash/backfila/ui/components/DashboardPageLayout.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/components/DashboardPageLayout.kt
@@ -127,7 +127,7 @@ class DashboardPageLayout @Inject constructor(
           ) {
             div("py-10") {
               main {
-                div("mx-auto w-[90%] px-4 sm:px-6 lg:px-8") {
+                div("mx-auto w-full px-4 sm:px-6 lg:px-8") {
                   // TODO remove when new UI is stable and preferred
                   UseOldUIAlert()
 

--- a/service/src/main/kotlin/app/cash/backfila/ui/components/DashboardPageLayout.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/components/DashboardPageLayout.kt
@@ -127,8 +127,7 @@ class DashboardPageLayout @Inject constructor(
           ) {
             div("py-10") {
               main {
-                // Use full width for better table display
-                div("mx-auto max-w-full px-4 sm:px-6 lg:px-8") {
+                div("mx-auto w-[90%] px-4 sm:px-6 lg:px-8") {
                   // TODO remove when new UI is stable and preferred
                   UseOldUIAlert()
 


### PR DESCRIPTION
implementing a responsive full-width layout that better utilizes available screen space while maintaining readability

- Changed DashboardPageLayout to full width utilization for better width utilization from max-w-7xl

Before 
https://github.com/user-attachments/assets/bab8b087-829b-46c0-b563-fa3a21c8c6d6

After - no need to horizontally scroll for larger screen size.

https://github.com/user-attachments/assets/ad2d565a-3abc-4f57-93da-6cfc4031c4ce
https://github.com/user-attachments/assets/9233e6c2-433c-4b1b-9fe2-e1fdb7ba7afd

