### PR TITLE
Only keep max width for shards and logs

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
@@ -216,7 +216,7 @@ class BackfillShowAction @Inject constructor(
             }
           }
 
-          Card {
+          FullWidthCard {
             // Partitions
             div("mx-auto max-w-7xl sm:px-6 lg:px-8") {
               h2("text-base font-semibold leading-6 text-gray-900") { +"""Partitions""" }
@@ -329,7 +329,7 @@ class BackfillShowAction @Inject constructor(
 
         // Smart auto-reload section for Events (preserves expanded state)
         AutoReload(frameId = "backfill-$id-events") {
-          Card {
+          FullWidthCard {
             // Events
             div("mx-auto max-w-7xl sm:px-6 lg:px-8") {
               h2("text-base font-semibold leading-6 text-gray-900") { +"""Events""" }
@@ -523,6 +523,12 @@ class BackfillShowAction @Inject constructor(
 
   private fun TagConsumer<*>.Card(block: TagConsumer<*>.() -> Unit) {
     div("-mx-4 mb-8 px-4 py-8 overflow-x-auto shadow-sm ring-1 ring-gray-900/5 sm:mx-0 sm:rounded-lg sm:px-8 lg:col-span-2 lg:row-span-2 lg:row-end-2") {
+      block()
+    }
+  }
+
+  private fun TagConsumer<*>.FullWidthCard(block: TagConsumer<*>.() -> Unit) {
+    div("-mx-2 mb-8 py-8 overflow-x-auto shadow-sm ring-1 ring-gray-900/5 sm:-mx-3 lg:-mx-4 sm:rounded-lg") {
       block()
     }
   }


### PR DESCRIPTION
Configuration and Overall Progress sections: Use the original constrained width
Partitions and Events tables: Use full width to accommodate data tables that benefit from more horizontal space (These are centered now)


Regular backfills with shorter logs and events - you can see that the contents are centered same with config and overall progress. The cards are full width still to accommodate the other error cases.

https://github.com/user-attachments/assets/02d75dfe-bf69-4e0e-ae0d-4a6b2bffc14e


Backfill with longer error messages. The content are still centered but utilizes the empty spaces now. 
https://github.com/user-attachments/assets/9b4d3a5f-d76a-404a-a829-5c38b36d4e6c



Small laptop screen still enables scrolling 

https://github.com/user-attachments/assets/191e3fd6-8c71-4b1c-bd2c-b72150d54bf0

Small laptop screen without errors

https://github.com/user-attachments/assets/737a7849-7d09-4450-bd1e-4cb116e283d5


