### PR TITLE
Fix development service by adding missing misk-grpc-reflect dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ miskService = { module = "com.squareup.misk:misk-service", version.ref = "misk" 
 miskSlack = { module = "com.squareup.misk:misk-slack", version.ref = "misk" }
 miskTailwind = { module = "com.squareup.misk:misk-tailwind", version.ref = "misk" }
 miskTesting = { module = "com.squareup.misk:misk-testing", version.ref = "misk" }
+miskGrpcReflect = { module = "com.squareup.misk:misk-grpc-reflect", version.ref = "misk" }
 miskVitess = { module = "com.squareup.misk:misk-vitess" }
 wireCompiler = { module = "com.squareup.wire:wire-compiler", version.ref = "wire" }
 wireGradlePlugin = { module = "com.squareup.wire:wire-gradle-plugin", version.ref = "wire" }

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
   implementation(libs.miskAdmin)
   implementation(libs.miskAuditClient)
   implementation(libs.miskCore)
+  implementation(libs.miskGrpcReflect)
   implementation(libs.miskHibernate)
   implementation(libs.miskHotwire)
   implementation(libs.miskInject)


### PR DESCRIPTION
- Add misk-grpc-reflect to libs.versions.toml
- Include misk-grpc-reflect in service dependencies
- Fixes NoClassDefFoundError: misk/grpc/reflect/GrpcReflectModule