### PR TITLE
[client-sqldelight-gradle-plugin] Update the generated methods and queries to be prefixed by the record source config name

### DIFF
--- a/client-sqldelight-gradle-plugin/src/main/kotlin/app/cash/backfila/client/sqldelight/plugin/GenerateBackfilaRecordSourceQueriesTask.kt
+++ b/client-sqldelight-gradle-plugin/src/main/kotlin/app/cash/backfila/client/sqldelight/plugin/GenerateBackfilaRecordSourceQueriesTask.kt
@@ -84,7 +84,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
           ).addFunction(
             FunSpec.builder("selectAbsoluteRange")
               .returns(minMaxQueryType)
-              .addStatement("return database.%L.${lowerName}SelectAbsoluteRange { min, max -> %T(min, max) }", queriesFunctionName, minMaxType)
+              .addStatement("return database.%L.%LSelectAbsoluteRange { min, max -> %T(min, max) }", queriesFunctionName, lowerName, minMaxType)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -93,7 +93,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("rangeEnd", keyType)
               .addParameter("scanSize", LONG)
               .returns(nullKeyContainerQueryType)
-              .addStatement("return database.%L.${lowerName}SelectInitialMaxBound(rangeStart, rangeEnd, scanSize) { %T(it) }", queriesFunctionName, nullKeyContainerType)
+              .addStatement("return database.%L.%LSelectInitialMaxBound(rangeStart, rangeEnd, scanSize) { %T(it) }", queriesFunctionName, lowerName, nullKeyContainerType)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -102,7 +102,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("rangeEnd", keyType)
               .addParameter("scanSize", LONG)
               .returns(nullKeyContainerQueryType)
-              .addStatement("return database.%L.${lowerName}SelectNextMaxBound(previousEndKey, rangeEnd, scanSize) { %T(it) }", queriesFunctionName, nullKeyContainerType)
+              .addStatement("return database.%L.%LSelectNextMaxBound(previousEndKey, rangeEnd, scanSize) { %T(it) }", queriesFunctionName, lowerName, nullKeyContainerType)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -111,7 +111,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("boundingMax", keyType)
               .addParameter("offset", LONG)
               .returns(keyQueryType)
-              .addStatement("return database.%L.${lowerName}ProduceInitialBatchFromRange(rangeStart, boundingMax, offset)", queriesFunctionName)
+              .addStatement("return database.%L.%LProduceInitialBatchFromRange(rangeStart, boundingMax, offset)", queriesFunctionName, lowerName)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -120,7 +120,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("boundingMax", keyType)
               .addParameter("offset", LONG)
               .returns(keyQueryType)
-              .addStatement("return database.%L.${lowerName}ProduceNextBatchFromRange(previousEndKey, boundingMax, offset)", queriesFunctionName)
+              .addStatement("return database.%L.%LProduceNextBatchFromRange(previousEndKey, boundingMax, offset)", queriesFunctionName, lowerName)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -128,7 +128,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("rangeStart", keyType)
               .addParameter("boundingMax", keyType)
               .returns(longQueryType)
-              .addStatement("return database.%L.${lowerName}CountInitialBatchMatches(rangeStart, boundingMax)", queriesFunctionName)
+              .addStatement("return database.%L.%LCountInitialBatchMatches(rangeStart, boundingMax)", queriesFunctionName, lowerName)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -136,7 +136,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("previousEndKey", keyType)
               .addParameter("boundingMax", keyType)
               .returns(longQueryType)
-              .addStatement("return database.%L.${lowerName}CountNextBatchMatches(previousEndKey, boundingMax)", queriesFunctionName)
+              .addStatement("return database.%L.%LCountNextBatchMatches(previousEndKey, boundingMax)", queriesFunctionName, lowerName)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -144,7 +144,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("rangeStart", keyType)
               .addParameter("batchEnd", keyType)
               .returns(minAndCountQueryType)
-              .addStatement("return database.%L.${lowerName}GetInitialStartKeyAndScanCount(rangeStart, batchEnd) { min, count -> %T(min, count) }", queriesFunctionName, minAndCountType)
+              .addStatement("return database.%L.%LGetInitialStartKeyAndScanCount(rangeStart, batchEnd) { min, count -> %T(min, count) }", queriesFunctionName, lowerName, minAndCountType)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -152,7 +152,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("previousEndKey", keyType)
               .addParameter("batchEnd", keyType)
               .returns(minAndCountQueryType)
-              .addStatement("return database.%L.${lowerName}GetNextStartKeyAndScanCount(previousEndKey, batchEnd) { min, count -> %T(min, count) }", queriesFunctionName, minAndCountType)
+              .addStatement("return database.%L.%LGetNextStartKeyAndScanCount(previousEndKey, batchEnd) { min, count -> %T(min, count) }", queriesFunctionName, lowerName, minAndCountType)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -160,7 +160,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("start", keyType)
               .addParameter("end", keyType)
               .returns(recordQueryType)
-              .addStatement("return database.%L.${lowerName}GetBatch(start, end)", queriesFunctionName)
+              .addStatement("return database.%L.%LGetBatch(start, end)", queriesFunctionName, lowerName)
               .addModifiers(OVERRIDE)
               .build(),
           ).build(),

--- a/client-sqldelight-gradle-plugin/src/main/kotlin/app/cash/backfila/client/sqldelight/plugin/GenerateBackfilaRecordSourceQueriesTask.kt
+++ b/client-sqldelight-gradle-plugin/src/main/kotlin/app/cash/backfila/client/sqldelight/plugin/GenerateBackfilaRecordSourceQueriesTask.kt
@@ -30,6 +30,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
   fun execute() {
     val backfillConfig = backfill.get()
     val name = backfillConfig.name.replaceFirstChar { it.uppercase() }
+    val lowerName = backfillConfig.name.replaceFirstChar { it.lowercase() }
     val packageName = packageName.get()
     val className = "${name}RecordSourceConfig"
     val targetDirectory = kotlinDirectory.asFile.get()
@@ -83,7 +84,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
           ).addFunction(
             FunSpec.builder("selectAbsoluteRange")
               .returns(minMaxQueryType)
-              .addStatement("return database.%L.selectAbsoluteRange { min, max -> %T(min, max) }", queriesFunctionName, minMaxType)
+              .addStatement("return database.%L.${lowerName}SelectAbsoluteRange { min, max -> %T(min, max) }", queriesFunctionName, minMaxType)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -92,7 +93,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("rangeEnd", keyType)
               .addParameter("scanSize", LONG)
               .returns(nullKeyContainerQueryType)
-              .addStatement("return database.%L.selectInitialMaxBound(rangeStart, rangeEnd, scanSize) { %T(it) }", queriesFunctionName, nullKeyContainerType)
+              .addStatement("return database.%L.${lowerName}SelectInitialMaxBound(rangeStart, rangeEnd, scanSize) { %T(it) }", queriesFunctionName, nullKeyContainerType)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -101,7 +102,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("rangeEnd", keyType)
               .addParameter("scanSize", LONG)
               .returns(nullKeyContainerQueryType)
-              .addStatement("return database.%L.selectNextMaxBound(previousEndKey, rangeEnd, scanSize) { %T(it) }", queriesFunctionName, nullKeyContainerType)
+              .addStatement("return database.%L.${lowerName}SelectNextMaxBound(previousEndKey, rangeEnd, scanSize) { %T(it) }", queriesFunctionName, nullKeyContainerType)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -110,7 +111,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("boundingMax", keyType)
               .addParameter("offset", LONG)
               .returns(keyQueryType)
-              .addStatement("return database.%L.produceInitialBatchFromRange(rangeStart, boundingMax, offset)", queriesFunctionName)
+              .addStatement("return database.%L.${lowerName}ProduceInitialBatchFromRange(rangeStart, boundingMax, offset)", queriesFunctionName)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -119,7 +120,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("boundingMax", keyType)
               .addParameter("offset", LONG)
               .returns(keyQueryType)
-              .addStatement("return database.%L.produceNextBatchFromRange(previousEndKey, boundingMax, offset)", queriesFunctionName)
+              .addStatement("return database.%L.${lowerName}ProduceNextBatchFromRange(previousEndKey, boundingMax, offset)", queriesFunctionName)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -127,7 +128,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("rangeStart", keyType)
               .addParameter("boundingMax", keyType)
               .returns(longQueryType)
-              .addStatement("return database.%L.countInitialBatchMatches(rangeStart, boundingMax)", queriesFunctionName)
+              .addStatement("return database.%L.${lowerName}CountInitialBatchMatches(rangeStart, boundingMax)", queriesFunctionName)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -135,7 +136,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("previousEndKey", keyType)
               .addParameter("boundingMax", keyType)
               .returns(longQueryType)
-              .addStatement("return database.%L.countNextBatchMatches(previousEndKey, boundingMax)", queriesFunctionName)
+              .addStatement("return database.%L.${lowerName}CountNextBatchMatches(previousEndKey, boundingMax)", queriesFunctionName)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -143,7 +144,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("rangeStart", keyType)
               .addParameter("batchEnd", keyType)
               .returns(minAndCountQueryType)
-              .addStatement("return database.%L.getInitialStartKeyAndScanCount(rangeStart, batchEnd) { min, count -> %T(min, count) }", queriesFunctionName, minAndCountType)
+              .addStatement("return database.%L.${lowerName}GetInitialStartKeyAndScanCount(rangeStart, batchEnd) { min, count -> %T(min, count) }", queriesFunctionName, minAndCountType)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -151,7 +152,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("previousEndKey", keyType)
               .addParameter("batchEnd", keyType)
               .returns(minAndCountQueryType)
-              .addStatement("return database.%L.getNextStartKeyAndScanCount(previousEndKey, batchEnd) { min, count -> %T(min, count) }", queriesFunctionName, minAndCountType)
+              .addStatement("return database.%L.${lowerName}GetNextStartKeyAndScanCount(previousEndKey, batchEnd) { min, count -> %T(min, count) }", queriesFunctionName, minAndCountType)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -159,7 +160,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("start", keyType)
               .addParameter("end", keyType)
               .returns(recordQueryType)
-              .addStatement("return database.%L.getBatch(start, end)", queriesFunctionName)
+              .addStatement("return database.%L.${lowerName}GetBatch(start, end)", queriesFunctionName)
               .addModifiers(OVERRIDE)
               .build(),
           ).build(),

--- a/client-sqldelight-gradle-plugin/src/main/kotlin/app/cash/backfila/client/sqldelight/plugin/GenerateBackfilaRecordSourceQueriesTask.kt
+++ b/client-sqldelight-gradle-plugin/src/main/kotlin/app/cash/backfila/client/sqldelight/plugin/GenerateBackfilaRecordSourceQueriesTask.kt
@@ -84,7 +84,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
           ).addFunction(
             FunSpec.builder("selectAbsoluteRange")
               .returns(minMaxQueryType)
-              .addStatement("return database.%L.%LSelectAbsoluteRange { min, max -> %T(min, max) }", queriesFunctionName, lowerName, minMaxType)
+              .addStatement("return database.%L.selectAbsoluteRange { min, max -> %T(min, max) }", queriesFunctionName, minMaxType)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -93,7 +93,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("rangeEnd", keyType)
               .addParameter("scanSize", LONG)
               .returns(nullKeyContainerQueryType)
-              .addStatement("return database.%L.%LSelectInitialMaxBound(rangeStart, rangeEnd, scanSize) { %T(it) }", queriesFunctionName, lowerName, nullKeyContainerType)
+              .addStatement("return database.%L.selectInitialMaxBound(rangeStart, rangeEnd, scanSize) { %T(it) }", queriesFunctionName, nullKeyContainerType)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -102,7 +102,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("rangeEnd", keyType)
               .addParameter("scanSize", LONG)
               .returns(nullKeyContainerQueryType)
-              .addStatement("return database.%L.%LSelectNextMaxBound(previousEndKey, rangeEnd, scanSize) { %T(it) }", queriesFunctionName, lowerName, nullKeyContainerType)
+              .addStatement("return database.%L.selectNextMaxBound(previousEndKey, rangeEnd, scanSize) { %T(it) }", queriesFunctionName, nullKeyContainerType)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -111,7 +111,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("boundingMax", keyType)
               .addParameter("offset", LONG)
               .returns(keyQueryType)
-              .addStatement("return database.%L.%LProduceInitialBatchFromRange(rangeStart, boundingMax, offset)", queriesFunctionName, lowerName)
+              .addStatement("return database.%L.produceInitialBatchFromRange(rangeStart, boundingMax, offset)", queriesFunctionName)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -120,7 +120,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("boundingMax", keyType)
               .addParameter("offset", LONG)
               .returns(keyQueryType)
-              .addStatement("return database.%L.%LProduceNextBatchFromRange(previousEndKey, boundingMax, offset)", queriesFunctionName, lowerName)
+              .addStatement("return database.%L.produceNextBatchFromRange(previousEndKey, boundingMax, offset)", queriesFunctionName)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -128,7 +128,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("rangeStart", keyType)
               .addParameter("boundingMax", keyType)
               .returns(longQueryType)
-              .addStatement("return database.%L.%LCountInitialBatchMatches(rangeStart, boundingMax)", queriesFunctionName, lowerName)
+              .addStatement("return database.%L.countInitialBatchMatches(rangeStart, boundingMax)", queriesFunctionName)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -136,7 +136,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("previousEndKey", keyType)
               .addParameter("boundingMax", keyType)
               .returns(longQueryType)
-              .addStatement("return database.%L.%LCountNextBatchMatches(previousEndKey, boundingMax)", queriesFunctionName, lowerName)
+              .addStatement("return database.%L.countNextBatchMatches(previousEndKey, boundingMax)", queriesFunctionName)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -144,7 +144,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("rangeStart", keyType)
               .addParameter("batchEnd", keyType)
               .returns(minAndCountQueryType)
-              .addStatement("return database.%L.%LGetInitialStartKeyAndScanCount(rangeStart, batchEnd) { min, count -> %T(min, count) }", queriesFunctionName, lowerName, minAndCountType)
+              .addStatement("return database.%L.getInitialStartKeyAndScanCount(rangeStart, batchEnd) { min, count -> %T(min, count) }", queriesFunctionName, minAndCountType)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(
@@ -152,7 +152,7 @@ abstract class GenerateBackfilaRecordSourceQueriesTask : DefaultTask() {
               .addParameter("previousEndKey", keyType)
               .addParameter("batchEnd", keyType)
               .returns(minAndCountQueryType)
-              .addStatement("return database.%L.%LGetNextStartKeyAndScanCount(previousEndKey, batchEnd) { min, count -> %T(min, count) }", queriesFunctionName, lowerName, minAndCountType)
+              .addStatement("return database.%L.getNextStartKeyAndScanCount(previousEndKey, batchEnd) { min, count -> %T(min, count) }", queriesFunctionName, minAndCountType)
               .addModifiers(OVERRIDE)
               .build(),
           ).addFunction(

--- a/client-sqldelight-gradle-plugin/src/main/kotlin/app/cash/backfila/client/sqldelight/plugin/GenerateBackfilaRecordSourceSqlTask.kt
+++ b/client-sqldelight-gradle-plugin/src/main/kotlin/app/cash/backfila/client/sqldelight/plugin/GenerateBackfilaRecordSourceSqlTask.kt
@@ -33,11 +33,11 @@ abstract class GenerateBackfilaRecordSourceSqlTask : DefaultTask() {
     sqlFile.parentFile.mkdirs()
     sqlFile.writeText(
       """
-    ${lowerName}SelectAbsoluteRange:
+    selectAbsoluteRange:
     SELECT min($key), max($key)
     FROM $table;
 
-    ${lowerName}SelectInitialMaxBound:
+    selectInitialMaxBound:
     SELECT MAX($key) FROM
      (SELECT DISTINCT $key FROM $table
       WHERE $key >= :backfillRangeStart
@@ -45,7 +45,7 @@ abstract class GenerateBackfilaRecordSourceSqlTask : DefaultTask() {
       ORDER BY $key ASC
       LIMIT :scanSize) AS subquery;
 
-    ${lowerName}SelectNextMaxBound:
+    selectNextMaxBound:
     SELECT MAX($key) FROM
      (SELECT DISTINCT $key FROM $table
       WHERE $key > :previousEndKey
@@ -53,17 +53,17 @@ abstract class GenerateBackfilaRecordSourceSqlTask : DefaultTask() {
       ORDER BY $key ASC
       LIMIT :scanSize) AS subquery;
 
-    ${lowerName}GetInitialStartKeyAndScanCount:
+    getInitialStartKeyAndScanCount:
     SELECT MIN($key), COUNT(*) FROM $table
     WHERE $key >= :backfillRangeStart
       AND $key <= :batchEnd;
 
-    ${lowerName}GetNextStartKeyAndScanCount:
+    getNextStartKeyAndScanCount:
     SELECT MIN($key), COUNT(*) FROM $table
     WHERE $key > :previousEndKey
       AND $key <= :batchEnd;
 
-    ${lowerName}ProduceInitialBatchFromRange:
+    produceInitialBatchFromRange:
     SELECT $key FROM $table
     WHERE $key >= :backfillRangeStart
       AND $key <= :boundingMax
@@ -72,7 +72,7 @@ abstract class GenerateBackfilaRecordSourceSqlTask : DefaultTask() {
     LIMIT 1
     OFFSET :offset;
 
-    ${lowerName}ProduceNextBatchFromRange:
+    produceNextBatchFromRange:
     SELECT $key FROM $table
     WHERE $key > :previousEndKey
       AND $key <= :boundingMax
@@ -81,13 +81,13 @@ abstract class GenerateBackfilaRecordSourceSqlTask : DefaultTask() {
     LIMIT 1
     OFFSET :offset;
 
-    ${lowerName}CountInitialBatchMatches:
+    countInitialBatchMatches:
     SELECT COUNT(DISTINCT $key) FROM $table
     WHERE $key >= :backfillRangeStart
       AND $key <= :boundingMax
       AND ( $where );
 
-    ${lowerName}CountNextBatchMatches:
+    countNextBatchMatches:
     SELECT COUNT(DISTINCT $key) FROM $table
     WHERE $key > :previousEndKey
       AND $key <= :boundingMax

--- a/client-sqldelight-gradle-plugin/src/test/projects/happyPath/lib/build.gradle.kts
+++ b/client-sqldelight-gradle-plugin/src/test/projects/happyPath/lib/build.gradle.kts
@@ -30,6 +30,27 @@ backfilaSqlDelight {
     recordColumns = "*",
     recordType = "app.cash.backfila.client.sqldelight.hockeydata.HockeyPlayer"
   )
+  addRecordSource(
+    name = "hockeyPlayerWithHeights",
+    database = "app.cash.backfila.client.sqldelight.hockeydata.HockeyDataDatabase",
+    tableName = "hockeyPlayer",
+    keyName = "player_number",
+    keyType = "kotlin.Int",
+    keyEncoder = "app.cash.backfila.client.sqldelight.IntKeyEncoder",
+    recordColumns = "*",
+    recordType = "app.cash.backfila.client.sqldelight.hockeydata.HockeyPlayerWithHeightsGetBatch",
+    whereClause = "height IS NOT NULL"
+  )
+  addRecordSource(
+    name = "hockeyPlayerNumbers",
+    database = "app.cash.backfila.client.sqldelight.hockeydata.HockeyDataDatabase",
+    tableName = "hockeyPlayer",
+    keyName = "player_number",
+    keyType = "kotlin.Int",
+    keyEncoder = "app.cash.backfila.client.sqldelight.IntKeyEncoder",
+    recordColumns = "player_number, full_name",
+    recordType = "app.cash.backfila.client.sqldelight.hockeydata.HockeyPlayerNumbersGetBatch"
+  )
 }
 
 dependencies {


### PR DESCRIPTION
## Description

This PR comes about from me running into issues with how backfila + sqldelight interact with each other and the generated code not doing _quite_ what I'd want it to do.

The TL;DR of my issue can be boiled down to:
* I have a table `users` with a column `phone_number`.
* The type of `phone_number` is `String?`
* I am trying to add a new record source that uses `whereClause = "phone_number IS NOT NULL"` in the config
* During code generation, sqldelight sees that `phone_number` no longer maps to the `users` table as the type is now `String` (because `whereClause = "phone_number IS NOT NULL"` enforces that `phone_number` couldn't possibly be null)
    * Because of this sqldelight creates a new record type matching the query name. In the case of the generated code from the gradle plugin, this type would be `GetBatch`.
* While I _could_ use `GetBatch` as the type, this is not very intuitive or "useful" (you wouldn't call and apple an orange).

## Solution

This PR updates the code generation to prefix the `getBatch` method and query with the record source config name.

So given the following
```kotlin
addRecordSource(
    name = "usersWithPhoneNumbers",
    ...
    whereClause = "phone_number IS NOT NULL"
)
```
The generated query would be `usersWithPhoneNumbersGetBatch` and the record type would be `UsersWithPhoneNumbersGetBatch`.

Not only does this change cover the `where x is not null` case, it also covers cases where you specify specific columns in the `recordColumns` field.

## Alternatives

Because sqldelight will default the type to the query name if the result doesn't match the table view, an alternative would be to drop the `getBatch` suffix from the generated code.

So given the following
```kotlin
addRecordSource(
    name = "usersWithPhoneNumbers",
    ...
    whereClause = "phone_number IS NOT NULL"
)
```

The generated query would be `usersWithPhoneNumbers` and the record type would be `UsersWithPhoneNumbers`.