### PR TITLE
Mark 'complete' for finished backfills

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
@@ -206,10 +206,14 @@ class BackfillShowAction @Inject constructor(
                     span("font-medium") { +"""Overall Progress""" }
                     span("font-semibold text-gray-900") {
                       if (allPrecomputingDone && totalItemsToRun > 0) {
-                        val percentage = (totalBackfilledItems.toDouble() / totalItemsToRun * 100).let {
-                          if (it.isNaN()) 0.0 else it
-                        }
+                        val percentage =
+                          (totalBackfilledItems.toDouble() / totalItemsToRun * 100).let {
+                            if (it.isNaN()) 0.0 else it
+                          }
                         +"""${String.format("%.1f", percentage)}%"""
+                      } else
+                        if (backfill.state == BackfillState.COMPLETE) {
+                        +"""Complete"""
                       } else {
                         +"""Computing..."""
                       }


### PR DESCRIPTION
Mark 'complete' for finished backfills

<img width="1222" height="311" alt="Screenshot 2025-08-18 at 9 48 34 AM" src="https://github.com/user-attachments/assets/c9568f0a-69e8-48cd-a038-580a8c20b066" />
