### PR TITLE
Make parameters classes easier to work with

### DIFF
--- a/client-base/src/main/kotlin/app/cash/backfila/client/spi/BackfillRegistration.kt
+++ b/client-base/src/main/kotlin/app/cash/backfila/client/spi/BackfillRegistration.kt
@@ -3,10 +3,12 @@ package app.cash.backfila.client.spi
 import java.time.Instant
 import kotlin.reflect.KClass
 
-data class BackfillRegistration @JvmOverloads constructor(
+data class BackfillRegistration
+@JvmOverloads
+constructor(
   val name: String,
   val description: String?,
-  val parametersClass: KClass<Any>,
+  val parametersClass: KClass<out Any>,
   val deleteBy: Instant?,
   val unit: String? = null,
 )

--- a/client-dynamodb-v2/src/main/kotlin/app/cash/backfila/client/dynamodbv2/internal/DynamoDbBackend.kt
+++ b/client-dynamodb-v2/src/main/kotlin/app/cash/backfila/client/dynamodbv2/internal/DynamoDbBackend.kt
@@ -21,13 +21,14 @@ import kotlin.reflect.full.findAnnotation
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 @Singleton
-class DynamoDbBackend @Inject constructor(
+class DynamoDbBackend
+@Inject
+constructor(
   private val injector: Injector,
   @ForDynamoDbBackend private val backfills: MutableMap<String, KClass<out DynamoDbBackfill<*, *>>>,
   private val dynamoDbClient: DynamoDbClient,
   val keyRangeCodec: DynamoDbKeyRangeCodec,
 ) : BackfillBackend {
-
   /** Creates Backfill instances. Each backfill ID gets a new Backfill instance. */
   private fun getBackfill(name: String): DynamoDbBackfill<*, *>? {
     val backfillClass = backfills[name]
@@ -38,14 +39,16 @@ class DynamoDbBackend @Inject constructor(
     }
   }
 
-  private fun <E : Any, Param : Any> createDynamoDbOperator(
-    backfill: DynamoDbBackfill<E, Param>,
-  ) = DynamoDbBackfillOperator(
-    dynamoDbClient,
-    backfill,
-    BackfilaParametersOperator(parametersClass(backfill::class)),
-    keyRangeCodec,
-  )
+  @Suppress("UNCHECKED_CAST")
+  private fun <E : Any, Param : Any> createDynamoDbOperator(backfill: DynamoDbBackfill<E, Param>) =
+    DynamoDbBackfillOperator(
+      dynamoDbClient,
+      backfill,
+      BackfilaParametersOperator(
+        parametersClass(backfill::class),
+      ) as BackfilaParametersOperator<Param>,
+      keyRangeCodec,
+    )
 
   override fun create(backfillName: String): BackfillOperator? {
     val backfill = getBackfill(backfillName)
@@ -58,19 +61,19 @@ class DynamoDbBackend @Inject constructor(
     return null
   }
 
-  override fun backfills(): Set<BackfillRegistration> {
-    return backfills.map {
-      BackfillRegistration(
-        name = it.key,
-        description = it.value.findAnnotation<Description>()?.text,
-        parametersClass = parametersClass(it.value as KClass<DynamoDbBackfill<Any, Any>>),
-        deleteBy = it.value.findAnnotation<DeleteBy>()?.parseDeleteByDate(),
-        unit = BackfillUnit.SEGMENTS.displayName,
-      )
-    }.toSet()
-  }
+  override fun backfills(): Set<BackfillRegistration> =
+    backfills
+      .map {
+        BackfillRegistration(
+          name = it.key,
+          description = it.value.findAnnotation<Description>()?.text,
+          parametersClass = parametersClass(it.value),
+          deleteBy = it.value.findAnnotation<DeleteBy>()?.parseDeleteByDate(),
+          unit = BackfillUnit.SEGMENTS.displayName,
+        )
+      }.toSet()
 
-  private fun <P : Any> parametersClass(backfillClass: KClass<out DynamoDbBackfill<*, P>>): KClass<P> {
+  private fun parametersClass(backfillClass: KClass<out DynamoDbBackfill<*, *>>): KClass<*> {
     // Like MyBackfill.
     val thisType = TypeLiteral.get(backfillClass.java)
 
@@ -78,6 +81,6 @@ class DynamoDbBackend @Inject constructor(
     val supertype = thisType.getSupertype(DynamoDbBackfill::class.java).type as ParameterizedType
 
     // Like MyParameterClass
-    return (Types.getRawType(supertype.actualTypeArguments[1]) as Class<P>).kotlin
+    return (Types.getRawType(supertype.actualTypeArguments[1])).kotlin
   }
 }

--- a/client-sqldelight/src/main/kotlin/app/cash/backfila/client/sqldelight/SqlDelightDatasourceBackfillModule.kt
+++ b/client-sqldelight/src/main/kotlin/app/cash/backfila/client/sqldelight/SqlDelightDatasourceBackfillModule.kt
@@ -34,11 +34,11 @@ class SqlDelightDatasourceBackfillModule<T : SqlDelightDatasourceBackfill<*, *, 
 
   override fun configure() {
     install(SqlDelightDatasourceBackfillBackendModule)
-    backfillBinder().addBinding(backfillClass.jvmName).to(backfillClass.java as Class<SqlDelightDatasourceBackfill<*, *, *>>)
+    backfillBinder().addBinding(backfillClass.jvmName).to(backfillClass.java)
     backfillRegistrationBinder().addBinding(backfillClass.jvmName).toInstance(registration)
   }
 
-  private fun parametersClass(): KClass<Any> {
+  private fun parametersClass(): KClass<out Any> {
     // Like MyBackfill.
     val thisType = TypeLiteral.get(backfillClass.java)
 
@@ -48,7 +48,7 @@ class SqlDelightDatasourceBackfillModule<T : SqlDelightDatasourceBackfill<*, *, 
     ).type as ParameterizedType
 
     // Like MyParameterClass
-    return (Types.getRawType(supertype.actualTypeArguments[2]) as Class<Any>).kotlin
+    return (Types.getRawType(supertype.actualTypeArguments[2])).kotlin
   }
 
   companion object {

--- a/client-sqldelight/src/main/kotlin/app/cash/backfila/client/sqldelight/internal/SqlDelightDatasourceBackend.kt
+++ b/client-sqldelight/src/main/kotlin/app/cash/backfila/client/sqldelight/internal/SqlDelightDatasourceBackend.kt
@@ -6,9 +6,13 @@ import app.cash.backfila.client.spi.BackfillOperator
 import app.cash.backfila.client.spi.BackfillRegistration
 import app.cash.backfila.client.sqldelight.ForSqlDelightBackend
 import app.cash.backfila.client.sqldelight.SqlDelightDatasourceBackfill
+import com.google.inject.TypeLiteral
+import com.squareup.moshi.Types
+import java.lang.reflect.ParameterizedType
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
+import kotlin.reflect.KClass
 
 @Singleton
 class SqlDelightDatasourceBackend @Inject constructor(
@@ -16,16 +20,29 @@ class SqlDelightDatasourceBackend @Inject constructor(
   @ForSqlDelightBackend private val registrations: Map<String, BackfillRegistration>,
 ) : BackfillBackend {
   override fun create(backfillName: String): BackfillOperator? {
-    val parametersClass = registrations[backfillName]?.parametersClass ?: return null
     val backfill = providers[backfillName]?.get() ?: return null
+    return createOperator(backfill)
+  }
 
-    @Suppress("UNCHECKED_CAST") // We don't know the types statically, so fake them.
-    backfill as SqlDelightDatasourceBackfill<Any, Any, Any>
+  @Suppress("UNCHECKED_CAST")
+  private fun <K : Any, R : Any, P : Any> createOperator(
+    backfill: SqlDelightDatasourceBackfill<K, R, P>,
+  ) = SqlDelightDatasourceBackfillOperator(
+    backfill,
+    BackfilaParametersOperator(
+      parametersClass(backfill::class),
+    ) as BackfilaParametersOperator<P>,
+  )
 
-    return SqlDelightDatasourceBackfillOperator(
-      backfill,
-      BackfilaParametersOperator(parametersClass),
-    )
+  private fun parametersClass(backfill: KClass<out SqlDelightDatasourceBackfill<*, *, *>>): KClass<*> {
+    // Like MyBackfill.
+    val thisType = TypeLiteral.get(backfill.java)
+
+    // Like S3DatasourceBackfill<MyParameterClass>.
+    val supertype = thisType.getSupertype(SqlDelightDatasourceBackfill::class.java).type as ParameterizedType
+
+    // Like MyParameterClass
+    return (Types.getRawType(supertype.actualTypeArguments[2])).kotlin
   }
 
   override fun backfills(): Set<BackfillRegistration> {


### PR DESCRIPTION
The key change is changing the type of
`BackfillRegistration.parametersClass` from `KClass<Any>` to `KClass<out Any>`. This is a clearer expression of the intent to allow backfill parameters to be of any type.

In the previous implementation, the type was `KClass<Any>` which actually means the class of the `Any` type. This required some gymnastics for the standard clients to be able to register themselves because they had to cast their parameters type to `Any` (usually by casting the backfill class to something like `SomeBackfill<Any, Any>` so that a parameters type of `Any` gets extracted).

With this change, a lot of these type gymnastics can be simplified. This also makes it much more straightforward to implement a custom client that uses a custom parameters type.