### PR TITLE
Fix backfill cloning for backfills not on first page

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
@@ -75,7 +75,7 @@ class BackfillCreateAction @Inject constructor(
     val backfillRuns = getBackfillRunsAction.backfillRuns(service, variant)
     var backfillToClone =
       (backfillRuns.paused_backfills + backfillRuns.running_backfills).firstOrNull { it.id == backfillIdToClone }
-    
+
     // If not found in first page, search through all pages for completed backfills
     if (backfillToClone == null && backfillIdToClone != null) {
       var paginationToken = backfillRuns.next_pagination_token

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillCreateAction.kt
@@ -73,8 +73,18 @@ class BackfillCreateAction @Inject constructor(
 
     // If service + variant + backfill id to clone are valid, pre-fill form with backfill details
     val backfillRuns = getBackfillRunsAction.backfillRuns(service, variant)
-    val backfillToClone =
+    var backfillToClone =
       (backfillRuns.paused_backfills + backfillRuns.running_backfills).firstOrNull { it.id == backfillIdToClone }
+    
+    // If not found in first page, search through all pages for completed backfills
+    if (backfillToClone == null && backfillIdToClone != null) {
+      var paginationToken = backfillRuns.next_pagination_token
+      while (paginationToken != null && backfillToClone == null) {
+        val nextPage = getBackfillRunsAction.backfillRuns(service, variant, paginationToken)
+        backfillToClone = nextPage.paused_backfills.firstOrNull { it.id == backfillIdToClone }
+        paginationToken = nextPage.next_pagination_token
+      }
+    }
     val backfillToCloneStatus = backfillToClone?.id?.toLongOrNull()?.let { getBackfillStatusAction.status(it) }
 
     val registeredBackfills = getRegisteredBackfillsAction.backfills(service, variant)


### PR DESCRIPTION
The backfill cloning feature was failing when trying to clone backfills that weren't on the first page of results. The GetBackfillRunsAction only returns 20 paused backfills per page, so any backfill beyond the first 20 (sorted by ID descending) would not be found during the cloning process.

Added pagination logic to search through all pages when the target backfill is not found on the first page: