### PR TITLE
bump pkey cursor size to 8192

### DIFF
--- a/service/src/main/resources/migrations/v022__backfila.sql
+++ b/service/src/main/resources/migrations/v022__backfila.sql
@@ -1,0 +1,6 @@
+-- Increase pkey_cursor and related columns to maximum varbinary size
+ALTER TABLE run_partitions
+    MODIFY COLUMN pkey_cursor varbinary(MAX NULL DEFAULT NULL,
+    MODIFY COLUMN pkey_range_start varbinary(1000) NULL DEFAULT NULL,
+    MODIFY COLUMN pkey_range_end varbinary(1000) NULL DEFAULT NULL,
+    MODIFY COLUMN precomputing_pkey_cursor varbinary(1000) NULL DEFAULT NULL;

--- a/service/src/main/resources/migrations/v022__backfila.sql
+++ b/service/src/main/resources/migrations/v022__backfila.sql
@@ -1,6 +1,6 @@
 -- Increase pkey_cursor and related columns to maximum varbinary size
 ALTER TABLE run_partitions
-    MODIFY COLUMN pkey_cursor varbinary(MAX NULL DEFAULT NULL,
+    MODIFY COLUMN pkey_cursor varbinary(1000) NULL DEFAULT NULL,
     MODIFY COLUMN pkey_range_start varbinary(1000) NULL DEFAULT NULL,
     MODIFY COLUMN pkey_range_end varbinary(1000) NULL DEFAULT NULL,
     MODIFY COLUMN precomputing_pkey_cursor varbinary(1000) NULL DEFAULT NULL;

--- a/service/src/main/resources/migrations/v022__backfila.sql
+++ b/service/src/main/resources/migrations/v022__backfila.sql
@@ -1,6 +1,6 @@
 -- Increase pkey_cursor and related columns to maximum varbinary size
 ALTER TABLE run_partitions
-    MODIFY COLUMN pkey_cursor varbinary(1000) NULL DEFAULT NULL,
-    MODIFY COLUMN pkey_range_start varbinary(1000) NULL DEFAULT NULL,
-    MODIFY COLUMN pkey_range_end varbinary(1000) NULL DEFAULT NULL,
-    MODIFY COLUMN precomputing_pkey_cursor varbinary(1000) NULL DEFAULT NULL;
+    MODIFY COLUMN pkey_cursor varbinary(5000) NULL DEFAULT NULL,
+    MODIFY COLUMN pkey_range_start varbinary(5000) NULL DEFAULT NULL,
+    MODIFY COLUMN pkey_range_end varbinary(5000) NULL DEFAULT NULL,
+    MODIFY COLUMN precomputing_pkey_cursor varbinary(5000) NULL DEFAULT NULL;

--- a/service/src/main/resources/migrations/v022__backfila.sql
+++ b/service/src/main/resources/migrations/v022__backfila.sql
@@ -1,6 +1,6 @@
 -- Increase pkey_cursor and related columns to maximum varbinary size
 ALTER TABLE run_partitions
-    MODIFY COLUMN pkey_cursor varbinary(5000) NULL DEFAULT NULL,
-    MODIFY COLUMN pkey_range_start varbinary(5000) NULL DEFAULT NULL,
-    MODIFY COLUMN pkey_range_end varbinary(5000) NULL DEFAULT NULL,
-    MODIFY COLUMN precomputing_pkey_cursor varbinary(5000) NULL DEFAULT NULL;
+    MODIFY COLUMN pkey_cursor varbinary(8192) NULL DEFAULT NULL,
+    MODIFY COLUMN pkey_range_start varbinary(8192) NULL DEFAULT NULL,
+    MODIFY COLUMN pkey_range_end varbinary(8192) NULL DEFAULT NULL,
+    MODIFY COLUMN precomputing_pkey_cursor varbinary(8192) NULL DEFAULT NULL;


### PR DESCRIPTION
(((Entity.Constants.MAX_ID_LENGTH_VALUE * 4) + 4) * 1.35).toInt()
Entity.Constants.MAX_ID_LENGTH_VALUE = 500
((500 * 4) + 4) * 1.35 = 2,705.4.



https://cash.slack.com/archives/C0151JAREE7/p1758735886277709







