### PR TITLE
Add soft-delete for service variants

### DIFF
--- a/service/api/service.api
+++ b/service/api/service.api
@@ -198,6 +198,15 @@ public final class app/cash/backfila/dashboard/CreateBackfillAction : misk/web/a
 	public final fun create (Ljava/lang/String;Ljava/lang/String;Lapp/cash/backfila/protos/service/CreateBackfillRequest;)Lapp/cash/backfila/protos/service/CreateBackfillResponse;
 }
 
+public final class app/cash/backfila/dashboard/DeleteServiceVariantAction : misk/web/actions/WebAction {
+	public static final field Companion Lapp/cash/backfila/dashboard/DeleteServiceVariantAction$Companion;
+	public fun <init> (Lmisk/hibernate/Transacter;Lmisk/hibernate/Query$Factory;Ljava/time/Clock;Lmisk/scope/ActionScoped;Lmisk/audit/AuditClient;)V
+	public final fun delete (Ljava/lang/String;Ljava/lang/String;)Lmisk/web/Response;
+}
+
+public final class app/cash/backfila/dashboard/DeleteServiceVariantAction$Companion {
+}
+
 public final class app/cash/backfila/dashboard/EditPartitionCursorAction : misk/web/actions/WebAction {
 	public static final field Companion Lapp/cash/backfila/dashboard/EditPartitionCursorAction$Companion;
 	public fun <init> (Lapp/cash/backfila/dashboard/GetBackfillStatusAction;Lapp/cash/backfila/ui/components/DashboardPageLayout;)V
@@ -977,6 +986,7 @@ public class app/cash/backfila/service/persistence/DbService : misk/hibernate/Db
 	public fun getConnector ()Ljava/lang/String;
 	public fun getConnector_extra_data ()Ljava/lang/String;
 	public fun getCreated_at ()Ljava/time/Instant;
+	public fun getDeleted_at ()Ljava/time/Instant;
 	public fun getId ()Lmisk/hibernate/Id;
 	public fun getLast_registered_at ()Ljava/time/Instant;
 	public fun getRegistry_name ()Ljava/lang/String;
@@ -986,6 +996,7 @@ public class app/cash/backfila/service/persistence/DbService : misk/hibernate/Db
 	public fun setConnector (Ljava/lang/String;)V
 	public fun setConnector_extra_data (Ljava/lang/String;)V
 	public fun setCreated_at (Ljava/time/Instant;)V
+	public fun setDeleted_at (Ljava/time/Instant;)V
 	public fun setId (Lmisk/hibernate/Id;)V
 	public fun setLast_registered_at (Ljava/time/Instant;)V
 	public fun setRegistry_name (Ljava/lang/String;)V
@@ -1019,6 +1030,7 @@ public abstract interface class app/cash/backfila/service/persistence/RunPartiti
 
 public abstract interface class app/cash/backfila/service/persistence/ServiceQuery : misk/hibernate/Query {
 	public abstract fun id (Lmisk/hibernate/Id;)Lapp/cash/backfila/service/persistence/ServiceQuery;
+	public abstract fun notDeleted ()Lapp/cash/backfila/service/persistence/ServiceQuery;
 	public abstract fun orderByName ()Lapp/cash/backfila/service/persistence/ServiceQuery;
 	public abstract fun orderByVariant ()Lapp/cash/backfila/service/persistence/ServiceQuery;
 	public abstract fun registryName (Ljava/lang/String;)Lapp/cash/backfila/service/persistence/ServiceQuery;

--- a/service/src/main/kotlin/app/cash/backfila/api/ConfigureServiceAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/api/ConfigureServiceAction.kt
@@ -55,6 +55,7 @@ class ConfigureServiceAction @Inject constructor(
     transacter.transaction { session ->
       val variantsForService = queryFactory.newQuery<ServiceQuery>()
         .registryName(service)
+        .notDeleted()
         .list(session)
 
       var dbService = variantsForService.firstOrNull() { it.variant == variant }

--- a/service/src/main/kotlin/app/cash/backfila/api/ConfigureServiceAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/api/ConfigureServiceAction.kt
@@ -55,13 +55,12 @@ class ConfigureServiceAction @Inject constructor(
     transacter.transaction { session ->
       val variantsForService = queryFactory.newQuery<ServiceQuery>()
         .registryName(service)
-        .notDeleted()
         .list(session)
 
       var dbService = variantsForService.firstOrNull() { it.variant == variant }
 
       if (dbService == null) {
-        check(variantsForService.size <= MAX_VARIANTS) { "Variant limit exceeded" }
+        check(variantsForService.count { it.deleted_at == null } <= MAX_VARIANTS) { "Variant limit exceeded" }
 
         dbService = DbService(
           service,
@@ -73,6 +72,10 @@ class ConfigureServiceAction @Inject constructor(
         )
         session.save(dbService)
       } else {
+        if (dbService.deleted_at != null) {
+          logger.info { "Reviving soft-deleted variant `$variant` of service `$service`" }
+          dbService.deleted_at = null
+        }
         dbService.connector = request.connector_type
         dbService.connector_extra_data = request.connector_extra_data
         dbService.slack_channel = request.slack_channel

--- a/service/src/main/kotlin/app/cash/backfila/dashboard/BackfilaWebActionsModule.kt
+++ b/service/src/main/kotlin/app/cash/backfila/dashboard/BackfilaWebActionsModule.kt
@@ -15,6 +15,7 @@ class BackfilaWebActionsModule() : KAbstractModule() {
     install(WebActionModule.create<GetRegisteredBackfillsAction>())
     install(WebActionModule.create<GetBackfillRunsAction>())
     install(WebActionModule.create<GetServiceDetailsAction>())
+    install(WebActionModule.create<DeleteServiceVariantAction>())
     install(WebActionModule.create<GetBackfillStatusAction>())
     install(WebActionModule.create<UpdateBackfillAction>())
     install(WebActionModule.create<ViewLogsAction>())

--- a/service/src/main/kotlin/app/cash/backfila/dashboard/DeleteServiceVariantAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/dashboard/DeleteServiceVariantAction.kt
@@ -1,0 +1,56 @@
+package app.cash.backfila.dashboard
+
+import app.cash.backfila.service.persistence.BackfilaDb
+import app.cash.backfila.service.persistence.BackfillRunQuery
+import app.cash.backfila.service.persistence.BackfillState
+import app.cash.backfila.service.persistence.ServiceQuery
+import java.time.Clock
+import javax.inject.Inject
+import misk.MiskCaller
+import misk.exceptions.BadRequestException
+import misk.hibernate.Query
+import misk.hibernate.Transacter
+import misk.hibernate.newQuery
+import misk.scope.ActionScoped
+import misk.security.authz.Authenticated
+import misk.web.PathParam
+import misk.web.Post
+import misk.web.RequestContentType
+import misk.web.ResponseContentType
+import misk.web.actions.WebAction
+import misk.web.mediatype.MediaTypes
+
+class DeleteServiceVariantAction @Inject constructor(
+  @BackfilaDb private val transacter: Transacter,
+  private val queryFactory: Query.Factory,
+  private val clock: Clock,
+  private val caller: @JvmSuppressWildcards ActionScoped<MiskCaller?>,
+) : WebAction {
+  @Post("/services/{service}/variants/{variant}/delete")
+  @RequestContentType(MediaTypes.APPLICATION_JSON)
+  @ResponseContentType(MediaTypes.APPLICATION_JSON)
+  @Authenticated(capabilities = ["users"])
+  fun delete(
+    @PathParam service: String,
+    @PathParam variant: String,
+  ) {
+    transacter.transaction { session ->
+      val dbService = queryFactory.newQuery<ServiceQuery>()
+        .registryName(service)
+        .variant(variant)
+        .notDeleted()
+        .uniqueResult(session) ?: throw BadRequestException("`$service`-`$variant` doesn't exist or is already deleted")
+
+      val runningBackfills = queryFactory.newQuery<BackfillRunQuery>()
+        .serviceId(dbService.id)
+        .state(BackfillState.RUNNING)
+        .list(session)
+
+      if (runningBackfills.isNotEmpty()) {
+        throw BadRequestException("Cannot delete `$service`-`$variant`: it has ${runningBackfills.size} running backfill(s)")
+      }
+
+      dbService.softDelete(clock)
+    }
+  }
+}

--- a/service/src/main/kotlin/app/cash/backfila/dashboard/DeleteServiceVariantAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/dashboard/DeleteServiceVariantAction.kt
@@ -4,36 +4,42 @@ import app.cash.backfila.service.persistence.BackfilaDb
 import app.cash.backfila.service.persistence.BackfillRunQuery
 import app.cash.backfila.service.persistence.BackfillState
 import app.cash.backfila.service.persistence.ServiceQuery
+import app.cash.backfila.ui.pages.ServiceIndexAction
+import jakarta.inject.Inject
 import java.time.Clock
-import javax.inject.Inject
 import misk.MiskCaller
+import misk.audit.AuditClient
 import misk.exceptions.BadRequestException
 import misk.hibernate.Query
 import misk.hibernate.Transacter
 import misk.hibernate.newQuery
+import misk.logging.getLogger
 import misk.scope.ActionScoped
 import misk.security.authz.Authenticated
 import misk.web.PathParam
 import misk.web.Post
-import misk.web.RequestContentType
+import misk.web.Response
+import misk.web.ResponseBody
 import misk.web.ResponseContentType
 import misk.web.actions.WebAction
 import misk.web.mediatype.MediaTypes
+import misk.web.toResponseBody
+import okhttp3.Headers
 
 class DeleteServiceVariantAction @Inject constructor(
   @BackfilaDb private val transacter: Transacter,
   private val queryFactory: Query.Factory,
   private val clock: Clock,
   private val caller: @JvmSuppressWildcards ActionScoped<MiskCaller?>,
+  private val auditClient: AuditClient,
 ) : WebAction {
   @Post("/services/{service}/variants/{variant}/delete")
-  @RequestContentType(MediaTypes.APPLICATION_JSON)
-  @ResponseContentType(MediaTypes.APPLICATION_JSON)
+  @ResponseContentType(MediaTypes.TEXT_HTML)
   @Authenticated(capabilities = ["users"])
   fun delete(
     @PathParam service: String,
     @PathParam variant: String,
-  ) {
+  ): Response<ResponseBody> {
     transacter.transaction { session ->
       val dbService = queryFactory.newQuery<ServiceQuery>()
         .registryName(service)
@@ -50,7 +56,26 @@ class DeleteServiceVariantAction @Inject constructor(
         throw BadRequestException("Cannot delete `$service`-`$variant`: it has ${runningBackfills.size} running backfill(s)")
       }
 
-      dbService.softDelete(clock)
+      dbService.deleted_at = clock.instant()
     }
+
+    val user = caller.get()?.principal ?: ""
+    logger.info { "Service variant `$service`-`$variant` soft deleted by `$user`" }
+    auditClient.logEvent(
+      target = variant,
+      description = "Service variant `$service`-`$variant` soft deleted by $user",
+      requestorLDAP = user,
+      applicationName = service,
+    )
+
+    return Response(
+      body = "go to ${ServiceIndexAction.PATH}".toResponseBody(),
+      statusCode = 303,
+      headers = Headers.headersOf("Location", ServiceIndexAction.PATH),
+    )
+  }
+
+  companion object {
+    private val logger = getLogger<DeleteServiceVariantAction>()
   }
 }

--- a/service/src/main/kotlin/app/cash/backfila/dashboard/GetServiceDetailsAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/dashboard/GetServiceDetailsAction.kt
@@ -41,6 +41,7 @@ class GetServiceDetailsAction @Inject constructor(
       val dbService = queryFactory.newQuery<ServiceQuery>()
         .registryName(service)
         .variant(variant)
+        .notDeleted()
         .uniqueResult(session) ?: throw BadRequestException("`$service`-`$variant` doesn't exist")
 
       GetServiceDetailsResponse(

--- a/service/src/main/kotlin/app/cash/backfila/dashboard/GetServiceVariantsAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/dashboard/GetServiceVariantsAction.kt
@@ -37,6 +37,7 @@ class GetServiceVariantsAction @Inject constructor(
     val variants = transacter.transaction { session ->
       val variantsForService = queryFactory.newQuery<ServiceQuery>()
         .registryName(service)
+        .notDeleted()
         .orderByVariant()
         .list(session)
 

--- a/service/src/main/kotlin/app/cash/backfila/dashboard/GetServicesAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/dashboard/GetServicesAction.kt
@@ -38,6 +38,7 @@ class GetServicesAction @Inject constructor(
 
     val services = transacter.transaction { session ->
       val variantsByService = queryFactory.newQuery<ServiceQuery>()
+        .notDeleted()
         .orderByName()
         .list(session)
         .groupBy { it.registry_name }

--- a/service/src/main/kotlin/app/cash/backfila/service/persistence/DbService.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/persistence/DbService.kt
@@ -1,5 +1,6 @@
 package app.cash.backfila.service.persistence
 
+import java.time.Clock
 import java.time.Instant
 import javax.persistence.Column
 import javax.persistence.Entity
@@ -40,6 +41,13 @@ class DbService() : DbUnsharded<DbService>, DbTimestampedEntity {
 
   @Column(nullable = true)
   var last_registered_at: Instant? = null
+
+  @Column(nullable = true)
+  var deleted_at: Instant? = null
+
+  fun softDelete(clock: Clock) {
+    deleted_at = clock.instant()
+  }
 
   constructor(
     registry_name: String,

--- a/service/src/main/kotlin/app/cash/backfila/service/persistence/DbService.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/persistence/DbService.kt
@@ -1,6 +1,5 @@
 package app.cash.backfila.service.persistence
 
-import java.time.Clock
 import java.time.Instant
 import javax.persistence.Column
 import javax.persistence.Entity
@@ -44,10 +43,6 @@ class DbService() : DbUnsharded<DbService>, DbTimestampedEntity {
 
   @Column(nullable = true)
   var deleted_at: Instant? = null
-
-  fun softDelete(clock: Clock) {
-    deleted_at = clock.instant()
-  }
 
   constructor(
     registry_name: String,

--- a/service/src/main/kotlin/app/cash/backfila/service/persistence/ServiceQuery.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/persistence/ServiceQuery.kt
@@ -2,6 +2,7 @@ package app.cash.backfila.service.persistence
 
 import misk.hibernate.Constraint
 import misk.hibernate.Id
+import misk.hibernate.Operator
 import misk.hibernate.Order
 import misk.hibernate.Query
 
@@ -20,4 +21,10 @@ interface ServiceQuery : Query<DbService> {
 
   @Constraint("id")
   fun id(id: Id<DbService>): ServiceQuery
+
+  @Constraint("deleted_at", Operator.IS_NULL)
+  fun notDeleted(): ServiceQuery
+
+  @Constraint("deleted_at", Operator.IS_NOT_NULL)
+  fun deleted(): ServiceQuery
 }

--- a/service/src/main/kotlin/app/cash/backfila/service/persistence/ServiceQuery.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/persistence/ServiceQuery.kt
@@ -24,7 +24,4 @@ interface ServiceQuery : Query<DbService> {
 
   @Constraint("deleted_at", Operator.IS_NULL)
   fun notDeleted(): ServiceQuery
-
-  @Constraint("deleted_at", Operator.IS_NOT_NULL)
-  fun deleted(): ServiceQuery
 }

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/ServiceInfoAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/ServiceInfoAction.kt
@@ -152,7 +152,7 @@ class ServiceInfoAction @Inject constructor(
                     method = FormMethod.post
                     button(classes = "inline-flex items-center px-4 py-2 border border-red-300 text-sm font-medium rounded-md text-red-700 bg-white hover:bg-red-50") {
                       type = ButtonType.submit
-                      onClick = "return confirm('Are you sure you want to delete the $service ($variant) service variant? This cannot be undone.')"
+                      attributes["onclick"] = "return confirm('Are you sure you want to delete the $service ($variant) service variant? This cannot be undone.')"
                       +"Delete Variant"
                     }
                   }

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/ServiceInfoAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/ServiceInfoAction.kt
@@ -8,7 +8,11 @@ import jakarta.inject.Singleton
 import java.net.HttpURLConnection
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import kotlinx.html.ButtonType
+import kotlinx.html.FormMethod
+import kotlinx.html.button
 import kotlinx.html.div
+import kotlinx.html.form
 import kotlinx.html.pre
 import kotlinx.html.span
 import misk.security.authz.Authenticated
@@ -136,6 +140,20 @@ class ServiceInfoAction @Inject constructor(
                           span("text-red-600 font-medium") { +"Never registered" }
                         }
                       }
+                    }
+                  }
+                }
+
+                // Danger zone
+                div("border-t border-red-200 pt-6") {
+                  span("text-sm font-medium text-red-600 block mb-4") { +"Danger Zone" }
+                  form {
+                    action = "/services/$service/variants/$variant/delete"
+                    method = FormMethod.post
+                    button(classes = "inline-flex items-center px-4 py-2 border border-red-300 text-sm font-medium rounded-md text-red-700 bg-white hover:bg-red-50") {
+                      type = ButtonType.submit
+                      onClick = "return confirm('Are you sure you want to delete the $service ($variant) service variant? This cannot be undone.')"
+                      +"Delete Variant"
                     }
                   }
                 }

--- a/service/src/main/resources/migrations/v024__backfila.sql
+++ b/service/src/main/resources/migrations/v024__backfila.sql
@@ -1,0 +1,1 @@
+ALTER TABLE services ADD COLUMN deleted_at TIMESTAMP(3) NULL;

--- a/service/src/test/kotlin/app/cash/backfila/actions/DeleteServiceVariantActionTest.kt
+++ b/service/src/test/kotlin/app/cash/backfila/actions/DeleteServiceVariantActionTest.kt
@@ -1,0 +1,196 @@
+package app.cash.backfila.actions
+
+import app.cash.backfila.BackfilaTestingModule
+import app.cash.backfila.api.ConfigureServiceAction
+import app.cash.backfila.client.Connectors
+import app.cash.backfila.dashboard.CreateBackfillAction
+import app.cash.backfila.dashboard.DeleteServiceVariantAction
+import app.cash.backfila.dashboard.GetServiceVariantsAction
+import app.cash.backfila.dashboard.GetServicesAction
+import app.cash.backfila.fakeCaller
+import app.cash.backfila.protos.service.ConfigureServiceRequest
+import app.cash.backfila.protos.service.CreateBackfillRequest
+import app.cash.backfila.service.persistence.BackfilaDb
+import app.cash.backfila.service.persistence.BackfillState
+import app.cash.backfila.service.persistence.DbBackfillRun
+import com.google.inject.Module
+import javax.inject.Inject
+import misk.exceptions.BadRequestException
+import misk.hibernate.Id
+import misk.hibernate.Query
+import misk.hibernate.Transacter
+import misk.hibernate.load
+import misk.scope.ActionScope
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+@MiskTest(startService = true)
+class DeleteServiceVariantActionTest {
+  @Suppress("unused")
+  @MiskTestModule
+  val module: Module = BackfilaTestingModule()
+
+  @Inject lateinit var configureServiceAction: ConfigureServiceAction
+  @Inject lateinit var deleteServiceVariantAction: DeleteServiceVariantAction
+  @Inject lateinit var getServicesAction: GetServicesAction
+  @Inject lateinit var getServiceVariantsAction: GetServiceVariantsAction
+  @Inject lateinit var createBackfillAction: CreateBackfillAction
+  @Inject @BackfilaDb lateinit var transacter: Transacter
+  @Inject lateinit var queryFactory: Query.Factory
+  @Inject lateinit var scope: ActionScope
+
+  @Test
+  fun `delete a variant with no running backfills`() {
+    scope.fakeCaller(service = "deep-fryer") {
+      configureServiceAction.configureService(
+        ConfigureServiceRequest.Builder()
+          .backfills(listOf())
+          .connector_type(Connectors.ENVOY)
+          .variant("playpen-jackf")
+          .build(),
+      )
+    }
+
+    scope.fakeCaller(user = "molly") {
+      deleteServiceVariantAction.delete("deep-fryer", "playpen-jackf")
+    }
+
+    val variants = scope.fakeCaller(user = "molly") {
+      getServiceVariantsAction.variants("deep-fryer")
+    }
+    assertThat(variants.variants.map { it.name }).doesNotContain("playpen-jackf")
+  }
+
+  @Test
+  fun `deleted variant does not appear in services list`() {
+    scope.fakeCaller(service = "deep-fryer") {
+      configureServiceAction.configureService(
+        ConfigureServiceRequest.Builder()
+          .backfills(listOf())
+          .connector_type(Connectors.ENVOY)
+          .variant("playpen-jackf")
+          .build(),
+      )
+    }
+
+    scope.fakeCaller(user = "molly") {
+      deleteServiceVariantAction.delete("deep-fryer", "playpen-jackf")
+    }
+
+    val services = scope.fakeCaller(user = "molly") {
+      getServicesAction.services()
+    }
+    val deepFryer = services.services.find { it.name == "deep-fryer" }
+    assertThat(deepFryer?.variants).doesNotContain("playpen-jackf")
+  }
+
+  @Test
+  fun `cannot delete a non-existent variant`() {
+    scope.fakeCaller(user = "molly") {
+      assertThatThrownBy {
+        deleteServiceVariantAction.delete("deep-fryer", "playpen-jackf")
+      }.isInstanceOf(BadRequestException::class.java)
+    }
+  }
+
+  @Test
+  fun `cannot delete an already-deleted variant`() {
+    scope.fakeCaller(service = "deep-fryer") {
+      configureServiceAction.configureService(
+        ConfigureServiceRequest.Builder()
+          .backfills(listOf())
+          .connector_type(Connectors.ENVOY)
+          .variant("playpen-jackf")
+          .build(),
+      )
+    }
+
+    scope.fakeCaller(user = "molly") {
+      deleteServiceVariantAction.delete("deep-fryer", "playpen-jackf")
+    }
+
+    scope.fakeCaller(user = "molly") {
+      assertThatThrownBy {
+        deleteServiceVariantAction.delete("deep-fryer", "playpen-jackf")
+      }.isInstanceOf(BadRequestException::class.java)
+    }
+  }
+
+  @Test
+  fun `cannot delete a variant with running backfills`() {
+    scope.fakeCaller(service = "deep-fryer") {
+      configureServiceAction.configureService(
+        ConfigureServiceRequest.Builder()
+          .backfills(
+            listOf(
+              ConfigureServiceRequest.BackfillData(
+                "ChickenSandwich", "Description", listOf(), null,
+                null, false, null, null,
+              ),
+            ),
+          )
+          .connector_type(Connectors.ENVOY)
+          .variant("playpen-jackf")
+          .build(),
+      )
+    }
+
+    val response = scope.fakeCaller(user = "molly") {
+      createBackfillAction.create(
+        "deep-fryer",
+        "playpen-jackf",
+        CreateBackfillRequest.Builder()
+          .backfill_name("ChickenSandwich")
+          .build(),
+      )
+    }
+
+    transacter.transaction { session ->
+      val backfill = session.load<DbBackfillRun>(Id(response.backfill_run_id))
+      backfill.setState(session, queryFactory, BackfillState.RUNNING)
+    }
+
+    scope.fakeCaller(user = "molly") {
+      assertThatThrownBy {
+        deleteServiceVariantAction.delete("deep-fryer", "playpen-jackf")
+      }.isInstanceOf(BadRequestException::class.java)
+        .hasMessageContaining("running backfill")
+    }
+  }
+
+  @Test
+  fun `re-registering a deleted variant creates a fresh row`() {
+    scope.fakeCaller(service = "deep-fryer") {
+      configureServiceAction.configureService(
+        ConfigureServiceRequest.Builder()
+          .backfills(listOf())
+          .connector_type(Connectors.ENVOY)
+          .variant("playpen-jackf")
+          .build(),
+      )
+    }
+
+    scope.fakeCaller(user = "molly") {
+      deleteServiceVariantAction.delete("deep-fryer", "playpen-jackf")
+    }
+
+    // Re-register the same variant - should succeed (creates new row)
+    scope.fakeCaller(service = "deep-fryer") {
+      configureServiceAction.configureService(
+        ConfigureServiceRequest.Builder()
+          .backfills(listOf())
+          .connector_type(Connectors.ENVOY)
+          .variant("playpen-jackf")
+          .build(),
+      )
+    }
+
+    val variants = scope.fakeCaller(user = "molly") {
+      getServiceVariantsAction.variants("deep-fryer")
+    }
+    assertThat(variants.variants.map { it.name }).contains("playpen-jackf")
+  }
+}

--- a/service/src/test/kotlin/app/cash/backfila/actions/DeleteServiceVariantActionTest.kt
+++ b/service/src/test/kotlin/app/cash/backfila/actions/DeleteServiceVariantActionTest.kt
@@ -13,13 +13,16 @@ import app.cash.backfila.protos.service.CreateBackfillRequest
 import app.cash.backfila.service.persistence.BackfilaDb
 import app.cash.backfila.service.persistence.BackfillState
 import app.cash.backfila.service.persistence.DbBackfillRun
+import app.cash.backfila.service.persistence.ServiceQuery
 import com.google.inject.Module
-import javax.inject.Inject
+import jakarta.inject.Inject
+import misk.audit.FakeAuditClient
 import misk.exceptions.BadRequestException
 import misk.hibernate.Id
 import misk.hibernate.Query
 import misk.hibernate.Transacter
 import misk.hibernate.load
+import misk.hibernate.newQuery
 import misk.scope.ActionScope
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
@@ -34,13 +37,23 @@ class DeleteServiceVariantActionTest {
   val module: Module = BackfilaTestingModule()
 
   @Inject lateinit var configureServiceAction: ConfigureServiceAction
+
   @Inject lateinit var deleteServiceVariantAction: DeleteServiceVariantAction
+
   @Inject lateinit var getServicesAction: GetServicesAction
+
   @Inject lateinit var getServiceVariantsAction: GetServiceVariantsAction
+
   @Inject lateinit var createBackfillAction: CreateBackfillAction
-  @Inject @BackfilaDb lateinit var transacter: Transacter
+
+  @Inject @BackfilaDb
+  lateinit var transacter: Transacter
+
   @Inject lateinit var queryFactory: Query.Factory
+
   @Inject lateinit var scope: ActionScope
+
+  @Inject lateinit var fakeAuditClient: FakeAuditClient
 
   @Test
   fun `delete a variant with no running backfills`() {
@@ -62,11 +75,21 @@ class DeleteServiceVariantActionTest {
       getServiceVariantsAction.variants("deep-fryer")
     }
     assertThat(variants.variants.map { it.name }).doesNotContain("playpen-jackf")
+
+    val auditEvent = fakeAuditClient.sentEvents.last()
+    assertThat(auditEvent.requestorLDAP).isEqualTo("molly")
+    assertThat(auditEvent.description).contains("deep-fryer").contains("playpen-jackf")
   }
 
   @Test
   fun `deleted variant does not appear in services list`() {
     scope.fakeCaller(service = "deep-fryer") {
+      configureServiceAction.configureService(
+        ConfigureServiceRequest.Builder()
+          .backfills(listOf())
+          .connector_type(Connectors.ENVOY)
+          .build(),
+      )
       configureServiceAction.configureService(
         ConfigureServiceRequest.Builder()
           .backfills(listOf())
@@ -84,7 +107,8 @@ class DeleteServiceVariantActionTest {
       getServicesAction.services()
     }
     val deepFryer = services.services.find { it.name == "deep-fryer" }
-    assertThat(deepFryer?.variants).doesNotContain("playpen-jackf")
+    assertThat(deepFryer).isNotNull()
+    assertThat(deepFryer!!.variants).contains("default").doesNotContain("playpen-jackf")
   }
 
   @Test
@@ -162,7 +186,7 @@ class DeleteServiceVariantActionTest {
   }
 
   @Test
-  fun `re-registering a deleted variant creates a fresh row`() {
+  fun `re-registering a deleted variant revives it in place`() {
     scope.fakeCaller(service = "deep-fryer") {
       configureServiceAction.configureService(
         ConfigureServiceRequest.Builder()
@@ -173,11 +197,20 @@ class DeleteServiceVariantActionTest {
       )
     }
 
+    val originalId = transacter.transaction { session ->
+      queryFactory.newQuery<ServiceQuery>()
+        .registryName("deep-fryer")
+        .variant("playpen-jackf")
+        .uniqueResult(session)!!
+        .id
+    }
+
     scope.fakeCaller(user = "molly") {
       deleteServiceVariantAction.delete("deep-fryer", "playpen-jackf")
     }
 
-    // Re-register the same variant - should succeed (creates new row)
+    // Re-register the same variant - revives the soft-deleted row rather than
+    // inserting a new one, which would collide with unq_registry_name_variant.
     scope.fakeCaller(service = "deep-fryer") {
       configureServiceAction.configureService(
         ConfigureServiceRequest.Builder()
@@ -192,5 +225,15 @@ class DeleteServiceVariantActionTest {
       getServiceVariantsAction.variants("deep-fryer")
     }
     assertThat(variants.variants.map { it.name }).contains("playpen-jackf")
+
+    val revived = transacter.transaction { session ->
+      queryFactory.newQuery<ServiceQuery>()
+        .registryName("deep-fryer")
+        .variant("playpen-jackf")
+        .notDeleted()
+        .uniqueResult(session)!!
+    }
+    assertThat(revived.id).isEqualTo(originalId)
+    assertThat(revived.deleted_at).isNull()
   }
 }


### PR DESCRIPTION
## Problem

Backfila supports service variants (e.g. `customermappings/playpen-jackf`, `customermappings/playpen-<ldap>`) but there was no way to delete them once created. Stale playpen variants accumulate over time with no way to clean them up through the UI or API.
<img width="1517" height="651" alt="Screenshot 2026-03-12 at 10 13 50 AM" src="https://github.com/user-attachments/assets/2a030674-8c79-4cca-ae73-a0dacba5b593" />

## Solution

Adds reversible soft-delete for service variants. A deleted variant is hidden from all listings and detail views; if the variant later re-registers via `configure_service`, the soft delete is reversed in place (same row, history preserved).

### Changes

**Database**
- Adds `deleted_at TIMESTAMP(3) NULL` column to the `services` table (`v024__backfila.sql`)
- Adds `ServiceQuery.notDeleted()` constraint using `IS_NULL` on `deleted_at`

**Backend**
- New `DeleteServiceVariantAction`: `POST /services/{service}/variants/{variant}/delete`
  - Requires `users` capability
  - Guards against deleting a variant that has running backfills
  - Returns 400 if the variant doesn't exist or is already deleted
  - Emits an `AuditClient` event attributing the deletion to the caller
  - Returns a 303 redirect back to the services index (it's the target of the UI form POST)
- Filters deleted variants from `GetServicesAction`, `GetServiceVariantsAction`, and `GetServiceDetailsAction`
- `ConfigureServiceAction` revives a soft-deleted variant in place (clears `deleted_at` on the existing row); deleted variants don't count toward the variant limit

**UI**
- Adds a "Danger Zone" section to the service info page (`/services/{service}/{variant}/info`) with a "Delete Variant" button and a confirmation dialog

### Design decisions

- **Soft delete only** — preserves historical backfill run data that references the `service_id` FK, consistent with how backfill run deletion works
- **Re-registration revives in place** (changed per review) — the previous fresh-row approach collided with `unq_registry_name_variant`; reviving the existing row avoids that and keeps the variant's backfill history
- **Block deletion if running backfills exist** — prevents orphaning active work
- **Audit via `AuditClient`** rather than `DbEventLog` — `event_logs.backfill_run_id` is `NOT NULL`, so a service-level event doesn't fit that table without a migration

## Testing

`DeleteServiceVariantActionTest` (runs against real MySQL with `unq_registry_name_variant` enforced) covers:
- Happy path deletion + audit event attribution
- Deleted variant hidden from services/variants listings while live variants stay visible
- 400 on non-existent or already-deleted variant
- 400 when running backfills exist
- Re-registration after deletion revives the same row (asserts the row id is unchanged and `deleted_at` is cleared)

Also verified end-to-end against a locally running `BackfilaDevelopmentService`:
- Info page renders the Danger Zone section
- Form POST soft-deletes the row (`deleted_at` stamped) and returns 303 to `/services/`
- Repeat POST returns 400; deleted variant's detail page shows the not-found error
- Full `:service:test` suite passes (113 tests)