### PR TITLE
Fix completed backfills not showing 100% progress

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/ui/components/BackfillsTable.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/components/BackfillsTable.kt
@@ -1,6 +1,7 @@
 package app.cash.backfila.ui.components
 
 import app.cash.backfila.dashboard.UiBackfillRun
+import app.cash.backfila.service.persistence.BackfillState
 import app.cash.backfila.ui.pages.BackfillShowAction
 import kotlinx.html.InputType
 import kotlinx.html.TagConsumer
@@ -80,7 +81,11 @@ fun TagConsumer<*>.BackfillsTable(
                   td(
                     "whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-0",
                   ) {
-                    ProgressBar(it.backfilled_matching_record_count, it.computed_matching_record_count, it.precomputing_done)
+                    if (it.state == BackfillState.COMPLETE) {
+                      ProgressBar(100, 100, true)
+                    } else {
+                      ProgressBar(it.backfilled_matching_record_count, it.computed_matching_record_count, it.precomputing_done)
+                    }
                   }
                   listOf(it.created_by_user, it.created_at, it.last_active_at).map {
                     td(

--- a/service/src/main/kotlin/app/cash/backfila/ui/components/ProgressBar.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/components/ProgressBar.kt
@@ -14,7 +14,7 @@ fun TagConsumer<*>.ProgressBar(
     val percentComplete = when {
       !precomputingDone -> null // Show indeterminate during precomputing
       denominator.toDouble() <= 0 -> 0.0 // Handle zero denominator
-      else -> round((numerator.toDouble() / denominator.toDouble()) * 100)
+      else -> round((numerator.toDouble() / denominator.toDouble()) * 100).coerceIn(0.0, 100.0)
     }
 
     // Show indeterminate progress bar during precomputing

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
@@ -180,6 +180,7 @@ class BackfillShowAction @Inject constructor(
               val totalItemsToRun = backfill.partitions.sumOf { it.computed_matching_record_count }
               val allPrecomputingDone = backfill.partitions.all { it.precomputing_done }
               val totalRate = backfill.partitions.sumOf { it.matching_records_per_minute ?: 0 }
+              val isComplete = backfill.state == BackfillState.COMPLETE
 
               div("my-6 space-y-4") {
                 div("text-sm text-gray-700") {
@@ -208,7 +209,9 @@ class BackfillShowAction @Inject constructor(
                   div("flex items-center justify-between text-sm text-gray-700 mb-2") {
                     span("font-medium") { +"""Overall Progress""" }
                     span("font-semibold text-gray-900") {
-                      if (allPrecomputingDone && totalItemsToRun > 0) {
+                      if (isComplete) {
+                        +"""100.0%"""
+                      } else if (allPrecomputingDone && totalItemsToRun > 0) {
                         val percentage =
                           (totalBackfilledItems.toDouble() / totalItemsToRun * 100).let {
                             if (it.isNaN()) 0.0 else it
@@ -223,11 +226,15 @@ class BackfillShowAction @Inject constructor(
                       }
                     }
                   }
-                  ProgressBar(
-                    totalBackfilledItems,
-                    totalItemsToRun,
-                    allPrecomputingDone,
-                  )
+                  if (isComplete) {
+                    ProgressBar(100, 100, true)
+                  } else {
+                    ProgressBar(
+                      totalBackfilledItems,
+                      totalItemsToRun,
+                      allPrecomputingDone,
+                    )
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Summary
- Backfills with state `COMPLETE` could show less than 100% progress when the backfilled count didn't exactly match the computed count
- Clamp `ProgressBar` percentage to `0–100%` via `.coerceIn(0.0, 100.0)`
- Override progress to 100% on both the backfill detail page and the backfills list table when state is `COMPLETE`

## Test plan
- [x] `./gradlew :service:build` passes
- [ ] Verify on a completed backfill (e.g. [#38168](https://backfila.sqprod.co/backfills/38168)) that progress now shows 100%
- [ ] Verify in-progress and paused backfills still show accurate partial progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)