### PR TITLE
Show progress percentage with one decimal and prevent overfill

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/ui/components/ProgressBar.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/components/ProgressBar.kt
@@ -1,6 +1,6 @@
 package app.cash.backfila.ui.components
 
-import kotlin.math.round
+import kotlin.math.floor
 import kotlinx.html.TagConsumer
 import kotlinx.html.div
 import kotlinx.html.style
@@ -14,7 +14,7 @@ fun TagConsumer<*>.ProgressBar(
     val percentComplete = when {
       !precomputingDone -> null // Show indeterminate during precomputing
       denominator.toDouble() <= 0 -> 0.0 // Handle zero denominator
-      else -> round((numerator.toDouble() / denominator.toDouble()) * 100)
+      else -> (numerator.toDouble() / denominator.toDouble()) * 100
     }
 
     // Show indeterminate progress bar during precomputing
@@ -24,11 +24,13 @@ fun TagConsumer<*>.ProgressBar(
         +"..."
       }
     } else {
+      // Floor to 1 decimal so the rendered width never overstates progress (e.g. 99.6% must not fill to 100%).
+      val displayPercent = floor(percentComplete * 10) / 10
       // Don't show blue sliver for 0%, just show the gray empty bar
-      val showPartialBarStyle = if (percentComplete > 0) "bg-blue-600" else ""
+      val showPartialBarStyle = if (displayPercent > 0) "bg-blue-600" else ""
       div("$showPartialBarStyle text-xs font-medium text-blue-100 text-center p-0.5 leading-none rounded-full") {
-        style = "width: $percentComplete%"
-        +"${percentComplete.toInt()}%"
+        style = "width: $displayPercent%"
+        +"${"%.1f".format(displayPercent)}%"
       }
     }
   }


### PR DESCRIPTION
## Summary
- The `ProgressBar` component rounded the computed percentage to a whole number with `round((numerator / denominator) * 100)`. At 99.6% this rounded to 100, so the bar visually filled to 100% and the label read "100%" while the backfill wasn't actually complete.
- Drop the rounding, compute the true percentage, and floor it to one decimal place. Use the same floored value for both the inline label and the `width:` style, so the rendered fill can never exceed the actual progress.
- Display the label with one decimal (e.g. `99.6%`).

## Notes
- `BackfillShowAction` already uses `String.format("%.1f", percentage)` for the standalone "Overall Progress" label above the bar, so this brings the bar's inline label in line with that.
- Floor (rather than round) at the displayed precision is intentional: it preserves the "not 100% until truly done" property at any precision.