### PR TITLE
Filter partitions by state and sort by progress

### DIFF
--- a/dev/seed_partitions.sql
+++ b/dev/seed_partitions.sql
@@ -1,0 +1,47 @@
+-- Dev-only seed for the partitions table UI (testing filter + sort).
+--
+-- Replaces an existing backfill_run's partitions with 10 synthetic rows in
+-- mixed states (RUNNING/PAUSED/COMPLETE/CANCELLED) and varied progress.
+--
+-- Usage:
+--   1. In the Backfila UI, create + start any backfill (e.g. BurgerFlippingBackfill).
+--   2. Find its backfill_run_id (visible in the backfill detail page URL, or:
+--        mysql -u root backfila_development -e \
+--          "SELECT id, state FROM backfill_runs ORDER BY id DESC LIMIT 5;"
+--   3. Run this script, passing the id via --init-command:
+--        mysql -u root backfila_development \
+--          --init-command="SET @run_id := <BACKFILL_RUN_ID>" \
+--          < dev/seed_partitions.sql
+--   4. Reload the backfill detail page.
+--
+-- Notes:
+--   - lease_expires_at is set near the MySQL TIMESTAMP cap (2038-01-19) to keep
+--     the real runner from leasing these rows. Values past 2038 silently get
+--     stored as zero — which Hibernate then rejects as "Zero date value prohibited".
+--   - If the parent backfill is RUNNING, the runner will skip these synthetic
+--     partitions (lease guard). If you want a truly static view, pause it.
+
+SELECT CONCAT('Seeding 10 synthetic partitions for backfill_run_id = ', @run_id) AS status;
+
+DELETE FROM run_partitions WHERE backfill_run_id = @run_id;
+
+INSERT INTO run_partitions
+  (backfill_run_id, partition_name, run_state, lease_expires_at,
+   pkey_range_start, pkey_range_end, pkey_cursor,
+   computed_scanned_record_count, computed_matching_record_count, precomputing_done,
+   backfilled_scanned_record_count, backfilled_matching_record_count,
+   scanned_records_per_minute, matching_records_per_minute)
+VALUES
+  (@run_id, 'shard-01-running-fast',      'RUNNING',   '2037-12-31 23:59:59', '0',  '5000',  '4500',  5000,  5000, 1,  4500,  4500, 1500, 1500),
+  (@run_id, 'shard-02-running-medium',    'RUNNING',   '2037-12-31 23:59:59', '0', '20000', '10000', 20000, 20000, 1, 10000, 10000,  800,  800),
+  (@run_id, 'shard-03-running-slow',      'RUNNING',   '2037-12-31 23:59:59', '0', '50000',  '5000', 50000, 50000, 1,  5000,  5000,  200,  200),
+  (@run_id, 'shard-04-running-stalled',   'RUNNING',   '2037-12-31 23:59:59', '0', '10000',  '3000', 10000, 10000, 1,  3000,  3000,    0,    0),
+  (@run_id, 'shard-05-running-computing', 'RUNNING',   '2037-12-31 23:59:59', '0', '10000',     '0',  3000,  3000, 0,     0,     0,  600,  600),
+  (@run_id, 'shard-06-paused-30pct',      'PAUSED',    '2037-12-31 23:59:59', '0', '10000',  '3000', 10000, 10000, 1,  3000,  3000, NULL, NULL),
+  (@run_id, 'shard-07-paused-near-done',  'PAUSED',    '2037-12-31 23:59:59', '0', '10000',  '9700', 10000, 10000, 1,  9700,  9700, NULL, NULL),
+  (@run_id, 'shard-08-complete-small',    'COMPLETE',  '2037-12-31 23:59:59', '0',  '2000',  '2000',  2000,  2000, 1,  2000,  2000, NULL, NULL),
+  (@run_id, 'shard-09-complete-big',      'COMPLETE',  '2037-12-31 23:59:59', '0', '40000', '40000', 40000, 40000, 1, 40000, 40000, NULL, NULL),
+  (@run_id, 'shard-10-cancelled-25pct',   'CANCELLED', '2037-12-31 23:59:59', '0', '10000',  '2500', 10000, 10000, 1,  2500,  2500, NULL, NULL);
+
+SELECT run_state, COUNT(*) AS n
+FROM run_partitions WHERE backfill_run_id = @run_id GROUP BY run_state;

--- a/service/src/main/kotlin/app/cash/backfila/ui/components/DashboardPageLayout.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/components/DashboardPageLayout.kt
@@ -112,6 +112,10 @@ class DashboardPageLayout @Inject constructor(
             type = "module"
             src = "/static/js/search_bar_controller.js"
           }
+          script {
+            type = "module"
+            src = "/static/js/partitions_table_controller.js"
+          }
           // Include any custom head block content
           headBlock()
         },

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
@@ -32,8 +32,11 @@ import kotlinx.html.dt
 import kotlinx.html.form
 import kotlinx.html.h2
 import kotlinx.html.input
+import kotlinx.html.label
+import kotlinx.html.option
 import kotlinx.html.pre
 import kotlinx.html.script
+import kotlinx.html.select
 import kotlinx.html.span
 import kotlinx.html.table
 import kotlinx.html.tbody
@@ -236,7 +239,39 @@ class BackfillShowAction @Inject constructor(
           FullWidthCard {
             // Partitions
             div("mx-auto max-w-7xl sm:px-6 lg:px-8") {
+              attributes["data-controller"] = "partitions-table"
               h2("text-base font-semibold leading-6 text-gray-900") { +"""Partitions""" }
+              div("mt-4 flex items-center gap-2") {
+                label(classes = "text-sm font-medium text-gray-700") {
+                  attributes["for"] = "partition-state-filter"
+                  +"""Filter by state:"""
+                }
+                select(classes = "rounded-md border border-gray-300 px-2 py-1 text-sm") {
+                  attributes["id"] = "partition-state-filter"
+                  attributes["data-partitions-table-target"] = "filter"
+                  attributes["data-action"] = "change->partitions-table#onFilterChange"
+                  option {
+                    attributes["value"] = "ALL"
+                    +"All"
+                  }
+                  option {
+                    attributes["value"] = "RUNNING"
+                    +"Running"
+                  }
+                  option {
+                    attributes["value"] = "PAUSED"
+                    +"Paused"
+                  }
+                  option {
+                    attributes["value"] = "COMPLETE"
+                    +"Complete"
+                  }
+                  option {
+                    attributes["value"] = "CANCELLED"
+                    +"Cancelled"
+                  }
+                }
+              }
               table("my-8 whitespace-nowrap text-left text-sm leading-6") {
                 thead("border-b border-gray-200 text-gray-900") {
                   tr {
@@ -266,7 +301,15 @@ class BackfillShowAction @Inject constructor(
                     }
                     th(classes = "py-3 pl-8 pr-0 text-right font-semibold") {
                       scope = ThScope.col
-                      +"""Progress (%)"""
+                      button(classes = "ml-auto inline-flex items-center gap-1 font-semibold hover:text-indigo-600") {
+                        type = ButtonType.button
+                        attributes["data-action"] = "click->partitions-table#toggleSort"
+                        +"""Progress (%)"""
+                        span("text-xs") {
+                          attributes["data-partitions-table-target"] = "sortIndicator"
+                          +"""↕"""
+                        }
+                      }
                     }
                     th(classes = "py-3 pl-8 pr-0 text-right font-semibold") {
                       scope = ThScope.col
@@ -285,8 +328,17 @@ class BackfillShowAction @Inject constructor(
                   }
                 }
                 tbody {
+                  attributes["data-partitions-table-target"] = "tbody"
                   backfill.partitions.map { partition ->
+                    val progressPct = if (partition.precomputing_done && partition.computed_matching_record_count > 0) {
+                      (partition.backfilled_matching_record_count.toDouble() / partition.computed_matching_record_count) * 100.0
+                    } else {
+                      -1.0
+                    }
                     tr("border-b border-gray-100") {
+                      attributes["data-partition-row"] = ""
+                      attributes["data-partition-state"] = partition.state.name
+                      attributes["data-progress-pct"] = progressPct.toString()
                       td("max-w-[50%] px-0 py-5 align-top") {
                         div("truncate font-medium text-gray-900") { +partition.name }
                       }

--- a/service/src/main/resources/web/static/js/partitions_table_controller.js
+++ b/service/src/main/resources/web/static/js/partitions_table_controller.js
@@ -1,0 +1,78 @@
+import { Application, Controller } from "../cache/stimulus/3.1.0/stimulus.min.js";
+window.Stimulus = Application.start();
+
+Stimulus.register("partitions-table", class extends Controller {
+  static targets = ["filter", "tbody", "sortIndicator"];
+
+  connect() {
+    const params = new URLSearchParams(window.location.search);
+    this.filter = (params.get("state") || "ALL").toUpperCase();
+    this.sort = params.get("sort") || "none";
+
+    if (this.hasFilterTarget) {
+      this.filterTarget.value = this.filter;
+    }
+    this.applyAll();
+  }
+
+  onFilterChange(ev) {
+    this.filter = ev.target.value;
+    this.updateUrl();
+    this.applyAll();
+  }
+
+  toggleSort() {
+    const next = { "none": "desc", "desc": "asc", "asc": "none" };
+    this.sort = next[this.sort] || "desc";
+    this.updateUrl();
+    this.applyAll();
+  }
+
+  updateUrl() {
+    const params = new URLSearchParams(window.location.search);
+    if (this.filter === "ALL") {
+      params.delete("state");
+    } else {
+      params.set("state", this.filter);
+    }
+    if (this.sort === "none") {
+      params.delete("sort");
+    } else {
+      params.set("sort", this.sort);
+    }
+    const qs = params.toString();
+    const newUrl = window.location.pathname + (qs ? "?" + qs : "");
+    history.replaceState(null, "", newUrl);
+  }
+
+  applyAll() {
+    if (!this.hasTbodyTarget) return;
+    const rows = Array.from(this.tbodyTarget.querySelectorAll("[data-partition-row]"));
+
+    rows.forEach(row => {
+      const state = row.getAttribute("data-partition-state");
+      const matches = this.filter === "ALL" || state === this.filter;
+      row.classList.toggle("hidden", !matches);
+    });
+
+    if (this.sort !== "none") {
+      const dir = this.sort === "asc" ? 1 : -1;
+      rows.sort((a, b) => {
+        const aPct = parseFloat(a.getAttribute("data-progress-pct"));
+        const bPct = parseFloat(b.getAttribute("data-progress-pct"));
+        const aUnknown = isNaN(aPct) || aPct < 0;
+        const bUnknown = isNaN(bPct) || bPct < 0;
+        if (aUnknown && !bUnknown) return 1;
+        if (!aUnknown && bUnknown) return -1;
+        if (aUnknown && bUnknown) return 0;
+        return (aPct - bPct) * dir;
+      });
+      rows.forEach(row => this.tbodyTarget.appendChild(row));
+    }
+
+    if (this.hasSortIndicatorTarget) {
+      this.sortIndicatorTarget.textContent =
+        this.sort === "asc" ? "▲" : this.sort === "desc" ? "▼" : "↕";
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- On the backfill detail page, the partitions table can be long and visually uniform. Adds a **state filter** (All / RUNNING / PAUSED / COMPLETE / CANCELLED) and **click-to-sort** on the Progress (%) header (cycles none → desc → asc → none).
- Both operate client-side via a small new Stimulus controller. State is persisted in the URL query string (`?state=RUNNING&sort=progress_desc`) so it survives the 10s auto-reload tick and is shareable.
- Partitions still computing progress are always sorted to the bottom regardless of sort direction.
- Includes `dev/seed_partitions.sql` for populating an existing backfill with mixed-state synthetic partitions to test the new UI locally.

## Implementation notes
- Pure additive change: row-level `data-partition-state` / `data-progress-pct` attributes are emitted server-side; the controller reads them, hides non-matching rows via the `hidden` class, and reorders via `tbody.appendChild`.
- No changes to `auto_reload_controller.js`. Because the controller's element lives inside the partitions turbo-frame, every auto-reload swap triggers a fresh `connect()` which re-reads the URL and re-applies filter + sort — no custom cross-frame events needed.

## Test plan
- [x] Start the dev service + a client (e.g. McDees), create + start a backfill.
- [x] Run `mysql -u root backfila_development --init-command="SET @run_id := <ID>" < dev/seed_partitions.sql` to seed 10 partitions in mixed states.
- [x] Reload the backfill detail page; verify all 10 rows render with the new filter dropdown and sortable Progress (%) header.
- [x] Change filter to `RUNNING` — only the 5 running rows remain.
- [x] Click Progress (%) — rows sort desc; computing/precomputing rows go to bottom. Click again for asc.
- [x] Wait through a 10s auto-reload tick; verify filter + sort persist.
- [x] Copy the URL and open in a new tab; verify filter + sort are restored from query string.

https://github.com/user-attachments/assets/2b356c34-6d10-439b-ad91-eda248a974e7

🤖 Generated with [Claude Code](https://claude.com/claude-code)