### PR TITLE
Remove unused jaeger-core dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,6 @@ sqldelightGradlePlugin = { module = "app.cash.sqldelight:gradle-plugin", version
 sqldelightJdbcDriver = { module = "app.cash.sqldelight:jdbc-driver", version.ref = "sqldelight" }
 sqldelightMysqlDialect = { module = "app.cash.sqldelight:mysql-dialect", version.ref = "sqldelight" }
 spotlessPlugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.12.0" }
-tracingJaeger = { module = "io.jaegertracing:jaeger-core", version = "1.1.0" }
 jooq = { module = "org.jooq:jooq", version.ref = "jooq" }
 kotlinAllOpenPlugin = { module = "org.jetbrains.kotlin:kotlin-allopen", version.ref = "kotlin" }
 kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/service-self-backfill/build.gradle.kts
+++ b/service-self-backfill/build.gradle.kts
@@ -46,7 +46,6 @@ dependencies {
   implementation(libs.retrofit)
   implementation(libs.retrofitGuavaAdapter)
   implementation(libs.retrofitWire)
-  implementation(libs.tracingJaeger)
   implementation(libs.wireRuntime)
   implementation(libs.wireCompiler)
   implementation(libs.wireSchema)

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -55,7 +55,6 @@ dependencies {
   implementation(libs.retrofit)
   implementation(libs.retrofitGuavaAdapter)
   implementation(libs.retrofitWire)
-  implementation(libs.tracingJaeger)
   implementation(libs.wireRuntime)
   implementation(libs.wireCompiler)
   implementation(libs.wireSchema)


### PR DESCRIPTION
The `io.jaegertracing:jaeger-core` dependency was declared in `gradle/libs.versions.toml` and wired into both `service` and `service-self-backfill`, but no source code references it. Removing it cleans up an unused dependency.

Changes:
- Drop the `tracingJaeger` entry from `gradle/libs.versions.toml`.
- Remove the `implementation(libs.tracingJaeger)` line from `service/build.gradle.kts` and `service-self-backfill/build.gradle.kts`.

Verification: `gradle :service:compileKotlin :service-self-backfill:compileKotlin` succeeds locally.