### PR TITLE
Update maven publishing plugin and switch to using a convention

### DIFF
--- a/.github/workflows/prepare_mkdocs.sh
+++ b/.github/workflows/prepare_mkdocs.sh
@@ -9,7 +9,7 @@
 set -ex
 
 # Generate the API docs
-gradle dokkaGfm
+gradle :docs:dokkaGenerateMarkdown
 
 # Dokka filenames like `-http-url/index.md` don't work well with MkDocs <title> tags.
 # Assign metadata to the file's first Markdown heading.
@@ -25,7 +25,7 @@ title_markdown_file() {
 }
 
 set +x
-for MARKDOWN_FILE in $(find docs/0.x/ -name '*.md'); do
+for MARKDOWN_FILE in $(find docs/build/dokka/markdown -name '*.md'); do
   echo $MARKDOWN_FILE
   title_markdown_file $MARKDOWN_FILE
 done

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Right-click on `BackfilaDevelopmentService.kt` and select `Run`
 Build a Docker image of backfila:
 
 ```
-$ docker build -t backfila-0.0.1
+$ docker build -t backfila-0.0.1 .
 ```
 
 #### Running locally

--- a/backfila-embedded/build.gradle.kts
+++ b/backfila-embedded/build.gradle.kts
@@ -29,6 +29,6 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/backfila-embedded/build.gradle.kts
+++ b/backfila-embedded/build.gradle.kts
@@ -1,12 +1,7 @@
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-
 plugins {
   kotlin("jvm")
   `java-library`
-  id("com.vanniktech.maven.publish.base")
+  id("kotlin-publishing-convention")
 }
 
 dependencies {
@@ -25,10 +20,4 @@ dependencies {
 
   testImplementation(libs.assertj)
   testImplementation(libs.kotlinTest)
-}
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
 }

--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
   `java-platform`
-  id("com.vanniktech.maven.publish.base")
+  id("publishing-convention")
 }
 
 dependencies {
   constraints {
     project.rootProject.subprojects.forEach { subproject ->
-      if (subproject.name != "bom") {
+      if (subproject.name !in listOf("bom", "client-sqldelight-test")) {
         api(subproject)
       }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
-import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.allopen.gradle.AllOpenExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@ import com.diffplug.gradle.spotless.SpotlessExtension
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.allopen.gradle.AllOpenExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -35,7 +34,7 @@ allprojects {
 
 subprojects {
   apply(plugin = "com.diffplug.spotless")
-  apply(plugin = "org.jetbrains.dokka")
+  apply(plugin = "dokka-convention")
   apply(plugin = "org.jetbrains.kotlin.plugin.allopen")
 
   tasks.withType<KotlinCompile> {
@@ -106,21 +105,6 @@ subprojects {
   configurations.all {
     if (name.contains("kapt") || name.contains("wire") || name.contains("proto")) {
       attributes.attribute(Usage.USAGE_ATTRIBUTE, this@subprojects.objects.named(Usage::class, Usage.JAVA_RUNTIME))
-    }
-  }
-
-  // We have to set the dokka configuration after evaluation since the com.vanniktech.maven.publish
-  // plugin overwrites our dokka configuration on projects where it's applied.
-  afterEvaluate {
-    tasks.withType(DokkaTask::class).configureEach {
-      dokkaSourceSets.configureEach {
-        reportUndocumented.set(false)
-        skipDeprecated.set(true)
-        jdkVersion.set(8)
-        if (name == "dokkaGfm") {
-          outputDirectory.set(project.file("$rootDir/docs/0.x"))
-        }
-      }
     }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.allopen.gradle.AllOpenExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -23,8 +22,6 @@ buildscript {
     classpath("app.cash.backfila:client-sqldelight-gradle-plugin")
   }
 }
-
-apply(plugin = "com.vanniktech.maven.publish.base")
 
 allprojects {
   group = project.property("GROUP") as String
@@ -104,48 +101,6 @@ subprojects {
   configurations.all {
     if (name.contains("kapt") || name.contains("wire") || name.contains("proto")) {
       attributes.attribute(Usage.USAGE_ATTRIBUTE, this@subprojects.objects.named(Usage::class, Usage.JAVA_RUNTIME))
-    }
-  }
-}
-
-
-allprojects {
-  plugins.withId("com.vanniktech.maven.publish.base") {
-    configure<PublishingExtension> {
-      // For the Gradle plugin's tests.
-      repositories {
-        maven {
-          name = "testMaven"
-          url = rootProject.layout.buildDirectory.dir("testMaven").get().asFile.toURI()
-        }
-      }
-    }
-    configure<MavenPublishBaseExtension> {
-      publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
-      signAllPublications()
-      pom {
-        description.set("Backfila is a service that manages backfill state, calling into other services to do batched work.")
-        name.set(project.name)
-        url.set("https://github.com/cashapp/backfila/")
-        licenses {
-          license {
-            name.set("The Apache Software License, Version 2.0")
-            url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-            distribution.set("repo")
-          }
-        }
-        scm {
-          url.set("https://github.com/cashapp/backfila/")
-          connection.set("scm:git:git://github.com/cashapp/backfila.git")
-          developerConnection.set("scm:git:ssh://git@github.com/cashapp/backfila.git")
-        }
-        developers {
-          developer {
-            id.set("square")
-            name.set("Square, Inc.")
-          }
-        }
-      }
     }
   }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+  `kotlin-dsl`
+}
+
+repositories {
+  mavenCentral()
+  gradlePluginPortal()
+}
+
+dependencies {
+  implementation(libs.dokkaGradlePlugin)
+  implementation(libs.kotlinGradlePlugin)
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,4 +10,5 @@ repositories {
 dependencies {
   implementation(libs.dokkaGradlePlugin)
   implementation(libs.kotlinGradlePlugin)
+  implementation(libs.mavenPublishGradlePlugin)
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,18 @@
+rootProject.name = "buildSrc"
+pluginManagement {
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("libs") {
+      from(files("../gradle/libs.versions.toml"))
+    }
+  }
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}

--- a/buildSrc/src/main/kotlin/dokka-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/dokka-convention.gradle.kts
@@ -1,0 +1,33 @@
+import org.jetbrains.dokka.gradle.formats.DokkaFormatPlugin
+import org.jetbrains.dokka.gradle.internal.InternalDokkaGradlePluginApi
+
+plugins {
+  id("org.jetbrains.dokka")
+}
+
+// Declares Markdown Gradle plugin
+@OptIn(InternalDokkaGradlePluginApi::class)
+abstract class DokkaMarkdownPlugin : DokkaFormatPlugin(formatName = "markdown") {
+  override fun DokkaFormatPlugin.DokkaFormatPluginContext.configure() {
+    project.dependencies {
+      // Sets up current project generation
+      dokkaPlugin(dokka("gfm-plugin"))
+
+      // Sets up multi-project generation
+      formatDependencies.dokkaPublicationPluginClasspathApiOnly.dependencies.addLater(
+        dokka("gfm-template-processing-plugin")
+      )
+    }
+  }
+}
+// Applies the plugin
+apply<DokkaMarkdownPlugin>()
+
+
+dokka {
+  dokkaSourceSets.configureEach {
+    reportUndocumented.set(false)
+    skipDeprecated.set(true)
+    jdkVersion.set(11)
+  }
+}

--- a/buildSrc/src/main/kotlin/kotlin-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-publishing-convention.gradle.kts
@@ -1,0 +1,14 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinJvm
+
+plugins {
+  id("publishing-convention")
+  id("dokka-convention")
+  kotlin("jvm")
+}
+mavenPublishing {
+
+  configure(
+    KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationMarkdown"))
+  )
+}

--- a/buildSrc/src/main/kotlin/publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/publishing-convention.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+  id("com.vanniktech.maven.publish.base")
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  signAllPublications()
+  pom {
+    description.set("Backfila is a service that manages backfill state, calling into other services to do batched work.")
+    name.set(project.name)
+    url.set("https://github.com/cashapp/backfila/")
+    licenses {
+      license {
+        name.set("The Apache Software License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    scm {
+      url.set("https://github.com/cashapp/backfila/")
+      connection.set("scm:git:git://github.com/cashapp/backfila.git")
+      developerConnection.set("scm:git:ssh://git@github.com/cashapp/backfila.git")
+    }
+    developers {
+      developer {
+        id.set("square")
+        name.set("Square, Inc.")
+      }
+    }
+  }
+}
+publishing {
+  // For the Gradle plugin's tests.
+  repositories {
+    maven {
+      name = "testMaven"
+      url = rootProject.layout.buildDirectory.dir("testMaven").get().asFile.toURI()
+    }
+  }
+}

--- a/client-base/build.gradle.kts
+++ b/client-base/build.gradle.kts
@@ -52,6 +52,6 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/client-base/build.gradle.kts
+++ b/client-base/build.gradle.kts
@@ -1,11 +1,7 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-
 plugins {
   kotlin("jvm")
   `java-library`
-  id("com.vanniktech.maven.publish.base")
+  id("kotlin-publishing-convention")
 }
 
 dependencies {
@@ -48,10 +44,4 @@ dependencies {
   // ****************************************
   // Can I make it any more obvious?
   // ****************************************
-}
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
 }

--- a/client-dynamodb-v2/build.gradle.kts
+++ b/client-dynamodb-v2/build.gradle.kts
@@ -1,11 +1,7 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-
 plugins {
   kotlin("jvm")
   `java-library`
-  id("com.vanniktech.maven.publish.base")
+  id("kotlin-publishing-convention")
 }
 
 dependencies {
@@ -61,10 +57,4 @@ dependencies {
       strictly("4.9.3")
     }
   }
-}
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
 }

--- a/client-dynamodb-v2/build.gradle.kts
+++ b/client-dynamodb-v2/build.gradle.kts
@@ -65,6 +65,6 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/client-dynamodb/build.gradle.kts
+++ b/client-dynamodb/build.gradle.kts
@@ -62,6 +62,6 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/client-dynamodb/build.gradle.kts
+++ b/client-dynamodb/build.gradle.kts
@@ -1,11 +1,7 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-
 plugins {
   kotlin("jvm")
   `java-library`
-  id("com.vanniktech.maven.publish.base")
+  id("kotlin-publishing-convention")
 }
 
 dependencies {
@@ -58,10 +54,4 @@ dependencies {
       strictly("4.9.3")
     }
   }
-}
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
 }

--- a/client-jooq/build.gradle.kts
+++ b/client-jooq/build.gradle.kts
@@ -1,6 +1,3 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import nu.studer.gradle.jooq.JooqEdition
 import nu.studer.gradle.jooq.JooqGenerate
 
@@ -19,7 +16,7 @@ plugins {
   `java-library`
   id("org.flywaydb.flyway") version "7.15.0"
   id("nu.studer.jooq") version "10.1.1"
-  id("com.vanniktech.maven.publish.base")
+  id("kotlin-publishing-convention")
 }
 
 dependencies {
@@ -123,9 +120,3 @@ tasks {
 }
 
 tasks.named<JooqGenerate>("generateJooq") { allInputsDeclared.set(true) }
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
-}

--- a/client-jooq/build.gradle.kts
+++ b/client-jooq/build.gradle.kts
@@ -126,6 +126,6 @@ tasks.named<JooqGenerate>("generateJooq") { allInputsDeclared.set(true) }
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/client-misk-dynamodb/build.gradle.kts
+++ b/client-misk-dynamodb/build.gradle.kts
@@ -16,6 +16,6 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/client-misk-dynamodb/build.gradle.kts
+++ b/client-misk-dynamodb/build.gradle.kts
@@ -1,21 +1,11 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-
 plugins {
   kotlin("jvm")
   `java-library`
-  id("com.vanniktech.maven.publish.base")
+  id("kotlin-publishing-convention")
 }
 
 dependencies {
   implementation(libs.kotlinStdLib)
 
   api(project(":client-dynamodb"))
-}
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
 }

--- a/client-misk-hibernate/build.gradle.kts
+++ b/client-misk-hibernate/build.gradle.kts
@@ -48,6 +48,6 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/client-misk-hibernate/build.gradle.kts
+++ b/client-misk-hibernate/build.gradle.kts
@@ -1,11 +1,7 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-
 plugins {
   kotlin("jvm")
   `java-library`
-  id("com.vanniktech.maven.publish.base")
+  id("kotlin-publishing-convention")
 }
 
 dependencies {
@@ -44,10 +40,4 @@ dependencies {
   testImplementation(project(":backfila-embedded"))
   testImplementation(project(":client-static"))
   testImplementation(project(":client-testing"))
-}
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
 }

--- a/client-misk-jooq/build.gradle.kts
+++ b/client-misk-jooq/build.gradle.kts
@@ -16,6 +16,6 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/client-misk-jooq/build.gradle.kts
+++ b/client-misk-jooq/build.gradle.kts
@@ -1,21 +1,11 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-
 plugins {
   kotlin("jvm")
   `java-library`
-  id("com.vanniktech.maven.publish.base")
+  id("kotlin-publishing-convention")
 }
 
 dependencies {
   implementation(libs.kotlinStdLib)
 
   api(project(":client-jooq"))
-}
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
 }

--- a/client-misk-static/build.gradle.kts
+++ b/client-misk-static/build.gradle.kts
@@ -1,20 +1,10 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-
 plugins {
   kotlin("jvm")
   `java-library`
-  id("com.vanniktech.maven.publish.base")
+  id("kotlin-publishing-convention")
 }
 dependencies {
   implementation(libs.kotlinStdLib)
 
   api(project(":client-static"))
-}
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
 }

--- a/client-misk-static/build.gradle.kts
+++ b/client-misk-static/build.gradle.kts
@@ -15,6 +15,6 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/client-misk/build.gradle.kts
+++ b/client-misk/build.gradle.kts
@@ -1,11 +1,7 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-
 plugins {
   kotlin("jvm")
   `java-library`
-  id("com.vanniktech.maven.publish.base")
+  id("kotlin-publishing-convention")
 }
 
 dependencies {
@@ -44,10 +40,4 @@ dependencies {
 
   testImplementation(project(":backfila-embedded"))
   testImplementation(project(":client-testing"))
-}
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
 }

--- a/client-misk/build.gradle.kts
+++ b/client-misk/build.gradle.kts
@@ -48,6 +48,6 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/client-s3/build.gradle.kts
+++ b/client-s3/build.gradle.kts
@@ -48,6 +48,6 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/client-s3/build.gradle.kts
+++ b/client-s3/build.gradle.kts
@@ -1,11 +1,7 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-
 plugins {
   kotlin("jvm")
   `java-library`
-  id("com.vanniktech.maven.publish.base")
+  id("kotlin-publishing-convention")
 }
 
 dependencies {
@@ -44,10 +40,4 @@ dependencies {
   testImplementation(libs.miskInject)
   testImplementation(libs.miskTesting)
   testImplementation(project(":client-misk"))
-}
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
 }

--- a/client-sqldelight-gradle-plugin/build.gradle.kts
+++ b/client-sqldelight-gradle-plugin/build.gradle.kts
@@ -1,15 +1,10 @@
-import com.vanniktech.maven.publish.GradlePlugin
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
   id("java-gradle-plugin")
   kotlin("jvm")
   id("com.github.gmazzo.buildconfig")
-  id("com.vanniktech.maven.publish.base")
 }
 
 // This module is used in two places:
@@ -23,13 +18,7 @@ plugins {
 //
 // We only want to publish when it's being built in the root project.
 if (rootProject.name == "backfila") {
-  configure<MavenPublishBaseExtension> {
-    configure(
-      GradlePlugin(
-        javadocJar = JavadocJar.Empty()
-      )
-    )
-  }
+  apply(plugin = "kotlin-publishing-convention")
 } else {
   // Move the build directory when included in build-support so as to not poison the real build.
   // If we don't there's a chance incorrect build config values (configured below) will be used.
@@ -69,28 +58,30 @@ gradlePlugin {
   }
 }
 
-tasks {
-  test {
-    // We do not want the tests to run within build-support.
-    // Note that by default intellij may still try to run them through build support.
-    if (rootProject.name != "backfila") {
-      onlyIf { false }
-      return@test
-    }
+// We do not want the tests to run within build-support.
+// Note that by default intellij may still try to run them through build support.
+if (rootProject.name == "backfila") {
+  tasks {
+    test {
 
-    useJUnitPlatform()
-    // The test in 'src/test/projects/android' needs Java 17+.
-    javaLauncher.set(
-      project.javaToolchains.launcherFor {
-        languageVersion.set(JavaLanguageVersion.of(17))
+      useJUnitPlatform()
+      // The test in 'src/test/projects/android' needs Java 17+.
+      javaLauncher.set(
+        project.javaToolchains.launcherFor {
+          languageVersion.set(JavaLanguageVersion.of(17))
+        }
+      )
+      systemProperty("backfilaVersion", rootProject.findProperty("VERSION_NAME") ?: "0.0-SNAPSHOT")
+      for (project in listOf(
+        ":client",
+        ":client-base",
+        ":client-sqldelight",
+        ":client-sqldelight-gradle-plugin"
+      )) {
+        dependsOn(project(project).getTasksByName("publishAllPublicationsToTestMavenRepository", false))
       }
-    )
-    systemProperty("backfilaVersion", rootProject.findProperty("VERSION_NAME") ?: "0.0-SNAPSHOT")
 
-    dependsOn(":client:publishAllPublicationsToTestMavenRepository")
-    dependsOn(":client-base:publishAllPublicationsToTestMavenRepository")
-    dependsOn(":client-sqldelight:publishAllPublicationsToTestMavenRepository")
-    dependsOn(":client-sqldelight-gradle-plugin:publishAllPublicationsToTestMavenRepository")
+    }
   }
 }
 

--- a/client-sqldelight/build.gradle.kts
+++ b/client-sqldelight/build.gradle.kts
@@ -1,11 +1,7 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-
 plugins {
   kotlin("jvm")
   `java-library`
-  id("com.vanniktech.maven.publish.base")
+  id("kotlin-publishing-convention")
 }
 
 dependencies {
@@ -27,10 +23,4 @@ dependencies {
   api(project(":client"))
   // We do not want to leak client-base implementation details to customers.
   implementation(project(":client-base"))
-}
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
 }

--- a/client-sqldelight/build.gradle.kts
+++ b/client-sqldelight/build.gradle.kts
@@ -31,6 +31,6 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/client-static/build.gradle.kts
+++ b/client-static/build.gradle.kts
@@ -47,6 +47,6 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/client-static/build.gradle.kts
+++ b/client-static/build.gradle.kts
@@ -1,11 +1,7 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-
 plugins {
   kotlin("jvm")
   `java-library`
-  id("com.vanniktech.maven.publish.base")
+  id("kotlin-publishing-convention")
 }
 
 dependencies {
@@ -43,10 +39,4 @@ dependencies {
   testImplementation(libs.miskInject)
   testImplementation(libs.miskTesting)
   testImplementation(project(":client-misk"))
-}
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
 }

--- a/client-testing/build.gradle.kts
+++ b/client-testing/build.gradle.kts
@@ -18,6 +18,6 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/client-testing/build.gradle.kts
+++ b/client-testing/build.gradle.kts
@@ -1,11 +1,7 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-
 plugins {
   kotlin("jvm")
   `java-library`
-  id("com.vanniktech.maven.publish.base")
+  id("kotlin-publishing-convention")
 }
 
 dependencies {
@@ -14,10 +10,4 @@ dependencies {
 
   implementation(libs.junitEngine)
   implementation(libs.assertj)
-}
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
 }

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -1,12 +1,7 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-
 plugins {
   kotlin("jvm")
   `java-library`
   id("com.squareup.wire")
-  id("com.vanniktech.maven.publish.base")
 }
 
 dependencies {
@@ -46,10 +41,4 @@ tasks.named("kotlinSourcesJar") {
 
 tasks.named("dokkaGeneratePublicationMarkdown") {
   dependsOn("generateMainProtos")
-}
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
 }

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -44,12 +44,12 @@ tasks.named("kotlinSourcesJar") {
   dependsOn("generateMainProtos")
 }
 
-tasks.named("dokkaGfm") {
+tasks.named("dokkaGeneratePublicationMarkdown") {
   dependsOn("generateMainProtos")
 }
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/deploy_website.sh
+++ b/deploy_website.sh
@@ -21,8 +21,8 @@ git clone $REPO $DIR
 cd $DIR
 
 # Generate the API docs
-GRADLE_TASKS=$(ls -d misk*/ | cut -f1 -d'/' | awk '{ printf ":%s:dokkaGfm ", $1 }')
-gradle dokkaGfm
+GRADLE_TASKS=$(ls -d misk*/ | cut -f1 -d'/' | awk '{ printf ":%s:dokkaGenerateMarkdown ", $1 }')
+gradle dokkaGenerateMarkdown
 
 # Copy in special files that GitHub wants in the project root.
 cat README.md | grep -v 'project website' > docs/index.md

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -1,0 +1,36 @@
+plugins {
+  kotlin("jvm") apply false
+  `dokka-convention`
+}
+
+dependencies {
+  project.rootProject.subprojects.forEach { subproject ->
+    if (subproject.name !in listOf("client-sqldelight-test"))
+      dokka(subproject)
+  }
+
+  // No version is necessary, Dokka will add it automatically
+  dokkaHtmlPlugin("org.jetbrains.dokka:versioning-plugin")
+}
+
+dokka {
+  moduleName.set("Backfila Docs")
+}
+
+val currentVersion = "0.3"
+val previousVersionsDirectory: Directory = layout.projectDirectory.dir("previousDocVersions")
+
+dokka {
+  pluginsConfiguration {
+    // Main configuration for the versioning plugin:
+    versioning {
+      // Generate documentation for the current version of the application.
+      version = currentVersion
+
+      // Look for previous versions of docs in the directory defined in
+      // `previousVersionsDirectory` allowing it to create the version
+      // navigation dropdown menu.
+      olderVersionsDir = previousVersionsDirectory
+    }
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ junitEngine = { module = "org.junit.jupiter:junit-jupiter-engine", version = "5.
 junitParams = { module = "org.junit.jupiter:junit-jupiter-params", version = "5.14.4" }
 logbackClassic = { module = "ch.qos.logback:logback-classic", version = "1.5.32" }
 loggingApi = { module = "io.github.microutils:kotlin-logging", version = "2.1.23" }
-mavenPublishGradlePlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.31.0" }
+mavenPublishGradlePlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.36.0" }
 moshiCore = { module = "com.squareup.moshi:moshi", version = "1.15.2" }
 moshiKotlin = { module = "com.squareup.moshi:moshi-kotlin", version = "1.15.2" }
 mysql = { module = "mysql:mysql-connector-java", version = "8.0.30" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ awsDynamodb = { module = "com.amazonaws:aws-java-sdk-dynamodb", version = "1.11.
 awsS3 = { module = "com.amazonaws:aws-java-sdk-s3", version = "1.12.231" }
 aws2S3 = { module = "software.amazon.awssdk:s3", version = "2.44.9" }
 buildConfigPlugin = { module = "com.github.gmazzo:gradle-buildconfig-plugin", version = "3.1.0" }
-dokkaGradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.0.0" }
+dokkaGradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.2.0" }
 guava = { module = "com.google.guava:guava", version = "33.6.0-jre" }
 guice = { module = "com.google.inject:guice", version = "6.0.0" }
 jCommander = { module = "com.beust:jcommander", version = "1.72" }

--- a/service-self-backfill/build.gradle.kts
+++ b/service-self-backfill/build.gradle.kts
@@ -75,6 +75,6 @@ dependencies {
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/service-self-backfill/build.gradle.kts
+++ b/service-self-backfill/build.gradle.kts
@@ -1,12 +1,8 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-
 plugins {
   kotlin("jvm")
   `java-library`
   id("com.diffplug.spotless")
-  id("com.vanniktech.maven.publish.base")
+  id("kotlin-publishing-convention")
 }
 
 dependencies {
@@ -71,10 +67,4 @@ dependencies {
   testImplementation(libs.slf4jApi)
 
   testImplementation(project(":backfila-embedded"))
-}
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
 }

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -1,12 +1,8 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
-import com.vanniktech.maven.publish.KotlinJvm
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-
 plugins {
   id("com.gradleup.shadow")
   kotlin("jvm")
   id("com.diffplug.spotless")
-  id("com.vanniktech.maven.publish.base")
+  id("kotlin-publishing-convention")
   id("com.squareup.wire")
 }
 
@@ -105,10 +101,4 @@ val shadowJar by tasks.getting(com.github.jengelman.gradle.plugins.shadow.tasks.
   mergeServiceFiles()
   isZip64 = true
   archiveClassifier.set("shaded")
-}
-
-configure<MavenPublishBaseExtension> {
-  configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
-  )
 }

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -109,6 +109,6 @@ val shadowJar by tasks.getting(com.github.jengelman.gradle.plugins.shadow.tasks.
 
 configure<MavenPublishBaseExtension> {
   configure(
-    KotlinJvm(javadocJar = Dokka("dokkaGfm"))
+    KotlinJvm(javadocJar = Dokka("dokkaGeneratePublicationMarkdown"))
   )
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ include("client-sqldelight-gradle-plugin")
 include("client-sqldelight-test")
 include("client-static")
 include("client-testing")
+include("docs")
 include("service")
 include("service-self-backfill")
 


### PR DESCRIPTION
Should be a lot easer to work with and make changes to now, as we don't need to deal with things being applied indiscriminately to the project.

This is based on top of the dokka branch as it relies on some of what was done there to work.

I did this anticipating it would solve some issues with how we publish the service, but in the end it wasn't strictly necessary. I still prefer it, and it's more gradle-y.