### PR TITLE
Depend on ReadyService and not SchemaMigrationService

### DIFF
--- a/service-self-backfill/src/main/kotlin/app/cash/backfila/service/selfbackfill/LocalBackfillingModule.kt
+++ b/service-self-backfill/src/main/kotlin/app/cash/backfila/service/selfbackfill/LocalBackfillingModule.kt
@@ -8,10 +8,9 @@ import app.cash.backfila.client.ForConnectors
 import app.cash.backfila.client.internal.BackfilaClient
 import app.cash.backfila.client.misk.hibernate.HibernateBackfillModule
 import app.cash.backfila.client.misk.internal.BackfilaStartupService
-import app.cash.backfila.service.persistence.BackfilaDb
+import misk.ReadyService
 import misk.ServiceModule
 import misk.inject.KAbstractModule
-import misk.jdbc.SchemaMigratorService
 
 // Connector type used only by backfila to backfill itself.
 private const val LOCAL = "LOCAL"
@@ -20,7 +19,7 @@ class LocalBackfillingModule : KAbstractModule() {
   override fun configure() {
     install(
       ServiceModule<BackfilaStartupService>()
-        .dependsOn<SchemaMigratorService>(BackfilaDb::class),
+        .dependsOn<ReadyService>(),
     )
 
     bind(BackfilaClientConfig::class.java).toInstance(

--- a/service/src/main/kotlin/app/cash/backfila/service/scheduler/RunnerSchedulerServiceModule.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/scheduler/RunnerSchedulerServiceModule.kt
@@ -1,15 +1,14 @@
 package app.cash.backfila.service.scheduler
 
-import app.cash.backfila.service.persistence.BackfilaDb
+import misk.ReadyService
 import misk.ServiceModule
 import misk.inject.KAbstractModule
-import misk.jdbc.SchemaMigratorService
 
 class RunnerSchedulerServiceModule : KAbstractModule() {
   override fun configure() {
     install(
       ServiceModule<RunnerSchedulerService>()
-        .dependsOn<SchemaMigratorService>(BackfilaDb::class),
+        .dependsOn<ReadyService>(),
     )
   }
 }


### PR DESCRIPTION
For self backfills, ReadyService is most appropriate, because backfila is actually registering itself, and therefore needs a working http api. Arguably it probably needs to wait for JettyService, but if SchemaMigrationService was sufficient, then ReadyService will also be fine.

RunnerSchedulerService is slightly more debatable. The lease hunter as designed expects a DB (which should be fully migrated), but in more general concept, one probably doesn't want to schedule runs or any of that until the service is 'ready'.

This is needed so I can use a different schema migrator than the built in one.