### PR TITLE
Report real DynamoDB scanned/matching record counts to metrics

### DIFF
--- a/backfila-embedded/api/backfila-embedded.api
+++ b/backfila-embedded/api/backfila-embedded.api
@@ -29,6 +29,8 @@ public abstract interface class app/cash/backfila/embedded/BackfillRun {
 	public abstract fun getPrepareBackfillResponse ()Lapp/cash/backfila/protos/clientservice/PrepareBackfillResponse;
 	public abstract fun getRangeEnd ()Ljava/lang/String;
 	public abstract fun getRangeStart ()Ljava/lang/String;
+	public abstract fun getRunMatchingCount ()J
+	public abstract fun getRunScannedCount ()J
 	public abstract fun getScanSize ()J
 	public abstract fun partitionScan (Ljava/lang/String;)Lapp/cash/backfila/protos/clientservice/GetNextBatchRangeResponse;
 	public abstract fun precomputeRemaining ()V

--- a/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/BackfillRun.kt
+++ b/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/BackfillRun.kt
@@ -27,6 +27,14 @@ interface BackfillRun<B : Backfill> {
   val precomputeMatchingCount: Long
   val precomputeScannedCount: Long
 
+  /**
+   * Real scanned/matching record counts reported by the operator's RunBatch responses so far,
+   * accumulated across all run batches. Operators that don't report counts (most SQL clients leave
+   * RunBatchResponse counts unset) contribute 0 here.
+   */
+  val runMatchingCount: Long
+  val runScannedCount: Long
+
   val partitionProgressSnapshot: Map<String, PartitionCursor>
 
   val batchesToRunSnapshot: List<BatchSnapshot>

--- a/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/internal/EmbeddedBackfillRun.kt
+++ b/backfila-embedded/src/main/kotlin/app/cash/backfila/embedded/internal/EmbeddedBackfillRun.kt
@@ -41,6 +41,8 @@ internal class EmbeddedBackfillRun<B : Backfill>(
   private val precomputeProgress: Map<String, MutablePartitionCursor>
   override var precomputeMatchingCount: Long = 0L
   override var precomputeScannedCount: Long = 0L
+  override var runMatchingCount: Long = 0L
+  override var runScannedCount: Long = 0L
 
   private val scanProgress: Map<String, MutablePartitionCursor>
   override val partitionProgressSnapshot: Map<String, PartitionCursor>
@@ -179,6 +181,8 @@ internal class EmbeddedBackfillRun<B : Backfill>(
       check(response.exception_stack_trace == null) {
         "RunBatch returned stack trace: ${response.exception_stack_trace}"
       }
+      runMatchingCount += response.matching_record_count ?: 0L
+      runScannedCount += response.scanned_record_count ?: 0L
       if (response.remaining_batch_range != null) {
         remainingRange = response.remaining_batch_range
       }

--- a/client-dynamodb-v2/src/main/kotlin/app/cash/backfila/client/dynamodbv2/internal/DynamoDbBackfillOperator.kt
+++ b/client-dynamodb-v2/src/main/kotlin/app/cash/backfila/client/dynamodbv2/internal/DynamoDbBackfillOperator.kt
@@ -149,6 +149,12 @@ class DynamoDbBackfillOperator<I : Any, P : Any>(
     val checkpointDuration = backfill.operatorStrategy?.checkpointSegmentProgressAfter
       ?: Duration.ofSeconds(2)
 
+    // Track the real counts the scan returns so we can report them back to Backfila. Unlike SQL
+    // clients we can't cheaply count up front in getNextBatchRange, but the scan result gives us
+    // these for free here. See RunBatchResponse in client_service.proto.
+    var scannedRecordCount = 0L
+    var matchingRecordCount = 0L
+
     val stopwatch = Stopwatch.createStarted()
     do {
       val scanRequest = ScanRequest.builder()
@@ -171,6 +177,11 @@ class DynamoDbBackfillOperator<I : Any, P : Any>(
 
       val result = dynamoDbClient.scan(scanRequest)
 
+      // scannedCount is everything examined; count is what remained after filterExpression. With no
+      // filter the two are equal, which is the correct matching/scanned ratio of 1.0.
+      scannedRecordCount += result.scannedCount().toLong()
+      matchingRecordCount += result.count().toLong()
+
       backfill.runBatch(
         result.items().map {
           dynamoDbTable.tableSchema().mapToItem(it)
@@ -184,6 +195,8 @@ class DynamoDbBackfillOperator<I : Any, P : Any>(
     } while (lastEvaluatedKey != null && lastEvaluatedKey.isNotEmpty())
 
     return RunBatchResponse.Builder()
+      .scanned_record_count(scannedRecordCount)
+      .matching_record_count(matchingRecordCount)
       .let {
         if (lastEvaluatedKey != null && lastEvaluatedKey.isNotEmpty()) {
           it.remaining_batch_range(lastEvaluatedKey.toKeyRange(keyRange))

--- a/client-dynamodb-v2/src/test/kotlin/app/cash/backfila/client/dynamodbv2/DynamoDbFilteringTest.kt
+++ b/client-dynamodb-v2/src/test/kotlin/app/cash/backfila/client/dynamodbv2/DynamoDbFilteringTest.kt
@@ -37,6 +37,11 @@ class DynamoDbFilteringTest {
     val run = backfila.createWetRun<FilteredMakeTracksExplicitBackfill>()
     run.execute()
     assertThat(run.backfill.nonTrackCount).isEqualTo(5)
+
+    // Without a DynamoDB filter expression everything is scanned and everything matches, so the
+    // reported matching/scanned counts are equal (the 5 album rows + 57 track rows).
+    assertThat(run.runScannedCount).isEqualTo(62)
+    assertThat(run.runMatchingCount).isEqualTo(62)
   }
 
   @Test
@@ -47,6 +52,11 @@ class DynamoDbFilteringTest {
     val run = backfila.createWetRun<DynamoFilterMakeTracksExplicitBackfill>()
     run.execute()
     assertThat(run.backfill.nonTrackCount).isEqualTo(0)
+
+    // The DynamoDB filter still scans every row but only the 57 track rows match, so the reported
+    // counts reflect the real sparseness (57 matching of 62 scanned).
+    assertThat(run.runScannedCount).isEqualTo(62)
+    assertThat(run.runMatchingCount).isEqualTo(57)
   }
 
   @Test

--- a/client-dynamodb/src/main/kotlin/app/cash/backfila/client/dynamodb/internal/DynamoDbBackfillOperator.kt
+++ b/client-dynamodb/src/main/kotlin/app/cash/backfila/client/dynamodb/internal/DynamoDbBackfillOperator.kt
@@ -115,6 +115,11 @@ class DynamoDbBackfillOperator<I : Any, P : Any>(
 
     var lastEvaluatedKey: Map<String, AttributeValue>? = keyRange.lastEvaluatedKey
 
+    // Track the real counts the scan returns so we can report them back to Backfila. The scan result
+    // gives us these for free. See RunBatchResponse in client_service.proto.
+    var scannedRecordCount = 0L
+    var matchingRecordCount = 0L
+
     val stopwatch = Stopwatch.createStarted()
     do {
       val scanRequest = DynamoDBScanExpression().apply {
@@ -130,6 +135,12 @@ class DynamoDbBackfillOperator<I : Any, P : Any>(
         this.indexName = backfill.indexName(config)
       }
       val result = dynamoDb.scanPage(backfill.itemType.java, scanRequest)
+
+      // scannedCount is everything examined; count is what remained after filterExpression. With no
+      // filter the two are equal, which is the correct matching/scanned ratio of 1.0.
+      scannedRecordCount += result.scannedCount.toLong()
+      matchingRecordCount += result.count.toLong()
+
       backfill.runBatch(result.results, config)
       lastEvaluatedKey = result.lastEvaluatedKey
       if (stopwatch.elapsed() > Duration.ofMillis(1_000L)) {
@@ -138,6 +149,8 @@ class DynamoDbBackfillOperator<I : Any, P : Any>(
     } while (lastEvaluatedKey != null)
 
     return RunBatchResponse.Builder()
+      .scanned_record_count(scannedRecordCount)
+      .matching_record_count(matchingRecordCount)
       .remaining_batch_range(lastEvaluatedKey?.toKeyRange(keyRange))
       .build()
   }

--- a/client-dynamodb/src/test/kotlin/app/cash/backfila/client/dynamodb/DynamoDbFilteringTest.kt
+++ b/client-dynamodb/src/test/kotlin/app/cash/backfila/client/dynamodb/DynamoDbFilteringTest.kt
@@ -32,6 +32,11 @@ class DynamoDbFilteringTest {
     val run = backfila.createWetRun<FilteredMakeTracksExplicitBackfill>()
     run.execute()
     assertThat(run.backfill.nonTrackCount).isEqualTo(5)
+
+    // Without a DynamoDB filter expression everything is scanned and everything matches, so the
+    // reported matching/scanned counts are equal (the 5 album rows + 57 track rows).
+    assertThat(run.runScannedCount).isEqualTo(62)
+    assertThat(run.runMatchingCount).isEqualTo(62)
   }
 
   @Test
@@ -42,6 +47,11 @@ class DynamoDbFilteringTest {
     val run = backfila.createWetRun<DynamoFilterMakeTracksExplicitBackfill>()
     run.execute()
     assertThat(run.backfill.nonTrackCount).isEqualTo(0)
+
+    // The DynamoDB filter still scans every row but only the 57 track rows match, so the reported
+    // counts reflect the real sparseness (57 matching of 62 scanned).
+    assertThat(run.runScannedCount).isEqualTo(62)
+    assertThat(run.runMatchingCount).isEqualTo(57)
   }
 
   @Test

--- a/client/api/client.api
+++ b/client/api/client.api
@@ -601,12 +601,16 @@ public final class app/cash/backfila/protos/clientservice/RunBatchResponse : com
 	public static final field ADAPTER Lcom/squareup/wire/ProtoAdapter;
 	public static final field DEFAULT_BACKOFF_MS Ljava/lang/Long;
 	public static final field DEFAULT_EXCEPTION_STACK_TRACE Ljava/lang/String;
+	public static final field DEFAULT_MATCHING_RECORD_COUNT Ljava/lang/Long;
+	public static final field DEFAULT_SCANNED_RECORD_COUNT Ljava/lang/Long;
 	public final field backoff_ms Ljava/lang/Long;
 	public final field exception_stack_trace Ljava/lang/String;
+	public final field matching_record_count Ljava/lang/Long;
 	public final field pipelined_data Lapp/cash/backfila/protos/clientservice/PipelinedData;
 	public final field remaining_batch_range Lapp/cash/backfila/protos/clientservice/KeyRange;
-	public fun <init> (Ljava/lang/Long;Lapp/cash/backfila/protos/clientservice/PipelinedData;Ljava/lang/String;Lapp/cash/backfila/protos/clientservice/KeyRange;)V
-	public fun <init> (Ljava/lang/Long;Lapp/cash/backfila/protos/clientservice/PipelinedData;Ljava/lang/String;Lapp/cash/backfila/protos/clientservice/KeyRange;Lokio/ByteString;)V
+	public final field scanned_record_count Ljava/lang/Long;
+	public fun <init> (Ljava/lang/Long;Lapp/cash/backfila/protos/clientservice/PipelinedData;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lapp/cash/backfila/protos/clientservice/KeyRange;)V
+	public fun <init> (Ljava/lang/Long;Lapp/cash/backfila/protos/clientservice/PipelinedData;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lapp/cash/backfila/protos/clientservice/KeyRange;Lokio/ByteString;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun newBuilder ()Lapp/cash/backfila/protos/clientservice/RunBatchResponse$Builder;
@@ -617,15 +621,19 @@ public final class app/cash/backfila/protos/clientservice/RunBatchResponse : com
 public final class app/cash/backfila/protos/clientservice/RunBatchResponse$Builder : com/squareup/wire/Message$Builder {
 	public field backoff_ms Ljava/lang/Long;
 	public field exception_stack_trace Ljava/lang/String;
+	public field matching_record_count Ljava/lang/Long;
 	public field pipelined_data Lapp/cash/backfila/protos/clientservice/PipelinedData;
 	public field remaining_batch_range Lapp/cash/backfila/protos/clientservice/KeyRange;
+	public field scanned_record_count Ljava/lang/Long;
 	public fun <init> ()V
 	public fun backoff_ms (Ljava/lang/Long;)Lapp/cash/backfila/protos/clientservice/RunBatchResponse$Builder;
 	public fun build ()Lapp/cash/backfila/protos/clientservice/RunBatchResponse;
 	public synthetic fun build ()Lcom/squareup/wire/Message;
 	public fun exception_stack_trace (Ljava/lang/String;)Lapp/cash/backfila/protos/clientservice/RunBatchResponse$Builder;
+	public fun matching_record_count (Ljava/lang/Long;)Lapp/cash/backfila/protos/clientservice/RunBatchResponse$Builder;
 	public fun pipelined_data (Lapp/cash/backfila/protos/clientservice/PipelinedData;)Lapp/cash/backfila/protos/clientservice/RunBatchResponse$Builder;
 	public fun remaining_batch_range (Lapp/cash/backfila/protos/clientservice/KeyRange;)Lapp/cash/backfila/protos/clientservice/RunBatchResponse$Builder;
+	public fun scanned_record_count (Ljava/lang/Long;)Lapp/cash/backfila/protos/clientservice/RunBatchResponse$Builder;
 }
 
 public final class app/cash/backfila/protos/service/CheckBackfillStatusRequest : com/squareup/wire/Message {

--- a/client/src/main/proto/app/cash/backfila/client_service.proto
+++ b/client/src/main/proto/app/cash/backfila/client_service.proto
@@ -118,6 +118,14 @@ message RunBatchResponse {
   // If this is provided this batch request is assumed to have failed.
   optional string exception_stack_trace = 3;
 
+  // Actual number of records scanned and matched while processing this RunBatch call. These are
+  // optional: clients that cannot cheaply count up front (e.g. the DynamoDB clients) can report the
+  // real counts here after scanning, while clients that don't populate them leave them unset and the
+  // service falls back to the GetNextBatchRange estimate. When a batch is split across multiple RPCs
+  // via remaining_batch_range, each RPC reports only the records it processed in that call.
+  optional uint64 scanned_record_count = 4;
+  optional uint64 matching_record_count = 5;
+
   // Provided data from the backfila client telling backfila what part of the batch was not
   // completed yet. Backfila will end up resuming with a new request containing either the remaining
   // range or the original range.

--- a/service/src/main/kotlin/app/cash/backfila/service/runner/statemachine/BatchAwaiter.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/runner/statemachine/BatchAwaiter.kt
@@ -79,6 +79,16 @@ class BatchAwaiter(
             // purposes of resetting the count of consecutive failures.
             backfillRunner.onRpcSuccess()
 
+            // If the client reported real counts for this partial chunk, record them now. Each RPC
+            // of a split batch carries only the records it processed, so we must accumulate per-RPC
+            // rather than waiting for the final RPC (which only knows about its own chunk).
+            if (response.matching_record_count != null || response.scanned_record_count != null) {
+              incCompletedRecordMetrics(
+                response.matching_record_count ?: 0L,
+                response.scanned_record_count ?: 0L,
+              )
+            }
+
             // We have a remaining_batch_range, continue the batch.
             remainingBatch = initialBatch.newBuilder()
               .batch_range(response.remaining_batch_range)
@@ -94,12 +104,21 @@ class BatchAwaiter(
 
             backfillRunner.factory.metrics.runBatchSuccesses
               .labels(*backfillRunner.metricLabels).inc()
-            backfillRunner.factory.metrics.runBatchCompletedRecordsMatching
-              .labels(*backfillRunner.metricLabels)
-              .inc(initialBatch.matching_record_count.toDouble())
-            backfillRunner.factory.metrics.runBatchCompletedRecordsScanned
-              .labels(*backfillRunner.metricLabels)
-              .inc(initialBatch.scanned_record_count.toDouble())
+            // Prefer the real counts reported by the client; fall back to the GetNextBatchRange
+            // estimate for clients that don't report them. Only metrics consume the actuals — the
+            // persisted backfilled_*_record_count, rate counters, and ETA below stay on the estimate
+            // so their units remain consistent with the precomputed (computed_*) totals.
+            if (response.matching_record_count != null || response.scanned_record_count != null) {
+              incCompletedRecordMetrics(
+                response.matching_record_count ?: 0L,
+                response.scanned_record_count ?: 0L,
+              )
+            } else {
+              incCompletedRecordMetrics(
+                initialBatch.matching_record_count,
+                initialBatch.scanned_record_count,
+              )
+            }
             backfillRunner.onRpcSuccess()
 
             matchingRateCounter.add(initialBatch.matching_record_count)
@@ -214,6 +233,15 @@ class BatchAwaiter(
     if (runComplete) {
       backfillRunner.factory.backfillRunListeners.forEach { it.runCompleted(backfillRunner.backfillRunId) }
     }
+  }
+
+  private fun incCompletedRecordMetrics(matching: Long, scanned: Long) {
+    backfillRunner.factory.metrics.runBatchCompletedRecordsMatching
+      .labels(*backfillRunner.metricLabels)
+      .inc(matching.toDouble())
+    backfillRunner.factory.metrics.runBatchCompletedRecordsScanned
+      .labels(*backfillRunner.metricLabels)
+      .inc(scanned.toDouble())
   }
 
   fun updateProgress(dbRunPartition: DbRunPartition) {


### PR DESCRIPTION
## Summary

The DynamoDB operators (both v1 and v2) hardcode `matching_record_count(1L)` / `scanned_record_count(1L)` per segment-batch in `getNextBatchRange`. Because each batch maps to one segment, these are effectively segment-completion counters: the matching/scanned ratio is always ≈1, so it can't be used as a sparseness signal.

Computing real counts up front in `getNextBatchRange` would require an extra scan of each segment (~2x read capacity, which the client deliberately avoids). But the scan that already runs in `runBatch` returns the true counts (`ScanResponse.count()`/`scannedCount()` in v2; `ScanResultPage.count`/`scannedCount` in v1) **for free**. This change reports those actuals.

This is the "metrics-only" variant: the real counts feed the `run_batch_completed_records_{matching,scanned}_total` Prometheus metrics, giving a meaningful matching/scanned ratio. Persisted progress (`backfilled_*_record_count`), the rate counters, and the ETA are intentionally left on the segment-based `getNextBatchRange` estimate so they stay consistent with the segment-based `computed_*` precomputed totals — making the progress bar/ETA themselves record-accurate would additionally require count-ahead in `getNextBatchRange` (a separate, more expensive change).

### Changes
- **proto**: add optional `scanned_record_count` (4) / `matching_record_count` (5) to `RunBatchResponse`. Optional + new tag numbers = wire-compatible; clients that don't set them are unaffected.
- **client-dynamodb / client-dynamodb-v2**: accumulate the scan result's counts across the checkpoint loop and report them on the response.
- **service `BatchAwaiter`**: use the client's actuals for the completed-records metrics when present (per-RPC, including the partial `remaining_batch_range` path), falling back to the estimate otherwise.
- **backfila-embedded**: expose `runMatchingCount` / `runScannedCount` on `BackfillRun` so the real counts are observable in tests.

## Test plan
- New assertions in v1 + v2 `DynamoDbFilteringTest`:
  - No filter expression → 62 scanned / 62 matching (ratio 1.0, as expected when nothing is filtered).
  - DynamoDB filter expression → 62 scanned / 57 matching (the real sparseness signal).
- `BackfillRunnerTest` passes unchanged, exercising the estimate-fallback path for clients that don't report counts.
- `service` and `backfila-embedded` compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)