### PR TITLE
Enforce required backfill approvals

### DIFF
--- a/service/api/service.api
+++ b/service/api/service.api
@@ -450,6 +450,9 @@ public final class app/cash/backfila/dashboard/StartBackfillAction$Companion {
 
 public final class app/cash/backfila/dashboard/StartBackfillRequest {
 	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getApprove ()Z
 }
 
 public final class app/cash/backfila/dashboard/StartBackfillResponse {

--- a/service/src/main/kotlin/app/cash/backfila/dashboard/BackfillStateToggler.kt
+++ b/service/src/main/kotlin/app/cash/backfila/dashboard/BackfillStateToggler.kt
@@ -8,6 +8,7 @@ import app.cash.backfila.service.persistence.BackfillState.RUNNING
 import app.cash.backfila.service.persistence.DbBackfillRun
 import app.cash.backfila.service.persistence.DbEventLog
 import jakarta.inject.Inject
+import java.time.Clock
 import misk.MiskCaller
 import misk.exceptions.BadRequestException
 import misk.hibernate.Id
@@ -21,7 +22,23 @@ class BackfillStateToggler @Inject constructor(
   private val queryFactory: Query.Factory,
   private val backfillRunListeners: Set<BackfillRunListener>,
 ) {
+  @Inject
+  private lateinit var clock: Clock
+
   fun toggleRunningState(id: Long, caller: MiskCaller, desiredState: BackfillState) {
+    toggleRunningState(id, caller, desiredState, approve = false)
+  }
+
+  internal fun approveAndStart(id: Long, caller: MiskCaller) {
+    toggleRunningState(id, caller, RUNNING, approve = true)
+  }
+
+  private fun toggleRunningState(
+    id: Long,
+    caller: MiskCaller,
+    desiredState: BackfillState,
+    approve: Boolean,
+  ) {
     val requiredCurrentState = when (desiredState) {
       PAUSED -> RUNNING
       RUNNING -> PAUSED
@@ -44,6 +61,9 @@ class BackfillStateToggler @Inject constructor(
           "backfill $id isn't $requiredCurrentState, can't move to state $desiredState",
         )
       }
+      if (desiredState == RUNNING) {
+        enforceApproval(run, caller, approve)
+      }
       run.setState(session, queryFactory, desiredState)
 
       val startedOrStopped = if (desiredState == RUNNING) "started" else "stopped"
@@ -63,6 +83,35 @@ class BackfillStateToggler @Inject constructor(
     } else {
       backfillRunListeners.forEach { it.runPaused(Id(id), caller.principal) }
     }
+  }
+
+  private fun enforceApproval(run: DbBackfillRun, caller: MiskCaller, approve: Boolean) {
+    if (!run.registered_backfill.requires_approval) return
+
+    val creator = run.created_by_user
+      ?: throw BadRequestException("backfill ${run.id.id} is missing its creator")
+    val approver = run.approved_by_user
+    val approvedAt = run.approved_at
+    if ((approver == null) != (approvedAt == null)) {
+      throw BadRequestException("backfill ${run.id.id} has incomplete approval")
+    }
+    if (approver != null) {
+      if (approver == creator) {
+        throw BadRequestException("backfill ${run.id.id} was approved by its creator")
+      }
+      return
+    }
+    if (!approve) {
+      throw BadRequestException("backfill ${run.id.id} requires approval before it can start")
+    }
+
+    val approvingUser = caller.user
+      ?: throw BadRequestException("backfill ${run.id.id} must be approved by an authenticated user")
+    if (approvingUser == creator) {
+      throw BadRequestException("backfill ${run.id.id} can't be approved by its creator")
+    }
+    run.approved_by_user = approvingUser
+    run.approved_at = clock.instant()
   }
 
   companion object {

--- a/service/src/main/kotlin/app/cash/backfila/dashboard/StartBackfillAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/dashboard/StartBackfillAction.kt
@@ -14,7 +14,7 @@ import misk.web.ResponseContentType
 import misk.web.actions.WebAction
 import misk.web.mediatype.MediaTypes
 
-class StartBackfillRequest
+class StartBackfillRequest(val approve: Boolean = false)
 class StartBackfillResponse
 
 class StartBackfillAction @Inject constructor(
@@ -34,7 +34,11 @@ class StartBackfillAction @Inject constructor(
   ): StartBackfillResponse {
     // TODO check user has permissions for this service with access api
     logger.info { "Start backfill $id by ${caller.get()?.user}" }
-    backfillStateToggler.toggleRunningState(id, caller.get()!!, BackfillState.RUNNING)
+    if (request.approve) {
+      backfillStateToggler.approveAndStart(id, caller.get()!!)
+    } else {
+      backfillStateToggler.toggleRunningState(id, caller.get()!!, BackfillState.RUNNING)
+    }
     return StartBackfillResponse()
   }
 

--- a/service/src/test/kotlin/app/cash/backfila/actions/CloneBackfillActionTest.kt
+++ b/service/src/test/kotlin/app/cash/backfila/actions/CloneBackfillActionTest.kt
@@ -19,12 +19,16 @@ import app.cash.backfila.protos.service.Parameter
 import app.cash.backfila.service.persistence.BackfilaDb
 import app.cash.backfila.service.persistence.BackfillRunQuery
 import app.cash.backfila.service.persistence.BackfillState
+import app.cash.backfila.service.persistence.DbBackfillRun
 import app.cash.backfila.service.persistence.RunPartitionQuery
 import com.google.inject.Module
 import jakarta.inject.Inject
+import java.time.Instant
 import misk.exceptions.BadRequestException
+import misk.hibernate.Id
 import misk.hibernate.Query
 import misk.hibernate.Transacter
+import misk.hibernate.load
 import misk.hibernate.newQuery
 import misk.scope.ActionScope
 import misk.testing.MiskTest
@@ -108,6 +112,11 @@ class CloneBackfillActionTest {
           .parameter_map(mapOf("param1" to "val1".encodeUtf8()))
           .build(),
       )
+      transacter.transaction { session ->
+        val source = session.load(Id<DbBackfillRun>(response.backfill_run_id))
+        source.approved_by_user = "diana"
+        source.approved_at = Instant.parse("2020-01-01T00:00:00Z")
+      }
 
       val cloneResponse = cloneBackfillAction.create(
         response.backfill_run_id,
@@ -133,6 +142,11 @@ class CloneBackfillActionTest {
       assertThat(status.scan_size).isEqualTo(223)
       assertThat(status.backoff_schedule).isEqualTo("1000,2000")
       assertThat(status.extra_sleep_ms).isEqualTo(15)
+      transacter.transaction { session ->
+        val clone = session.load(Id<DbBackfillRun>(cloneResponse.id))
+        assertThat(clone.approved_by_user).isNull()
+        assertThat(clone.approved_at).isNull()
+      }
     }
   }
 

--- a/service/src/test/kotlin/app/cash/backfila/actions/StartStopBackfillActionTest.kt
+++ b/service/src/test/kotlin/app/cash/backfila/actions/StartStopBackfillActionTest.kt
@@ -21,6 +21,7 @@ import app.cash.backfila.service.persistence.BackfillState
 import app.cash.backfila.service.persistence.DbBackfillRun
 import com.google.inject.Module
 import jakarta.inject.Inject
+import java.time.Instant
 import kotlin.test.assertNotNull
 import misk.exceptions.BadRequestException
 import misk.hibernate.Id
@@ -33,6 +34,8 @@ import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 @MiskTest(startService = true)
 class StartStopBackfillActionTest {
@@ -519,6 +522,67 @@ class StartStopBackfillActionTest {
     }
   }
 
+  @ParameterizedTest
+  @ValueSource(booleans = [true, false])
+  fun `required backfills need a different human approver for dry and wet runs`(dryRun: Boolean) {
+    val id = createApprovalBackfill(dryRun)
+
+    assertThatThrownBy {
+      scope.fakeCaller(user = "diana") {
+        startBackfillAction.start(id, StartBackfillRequest())
+      }
+    }.isInstanceOf(BadRequestException::class.java)
+    assertThatThrownBy {
+      scope.fakeCaller(service = "automation") {
+        startBackfillAction.start(id, StartBackfillRequest(approve = true))
+      }
+    }.isInstanceOf(BadRequestException::class.java)
+    assertThatThrownBy {
+      scope.fakeCaller(user = "molly") {
+        startBackfillAction.start(id, StartBackfillRequest(approve = true))
+      }
+    }.isInstanceOf(BadRequestException::class.java)
+
+    scope.fakeCaller(user = "diana") {
+      startBackfillAction.start(id, StartBackfillRequest(approve = true))
+      stopBackfillAction.stop(id, StopBackfillRequest())
+    }
+    scope.fakeCaller(user = "emma") {
+      startBackfillAction.start(id, StartBackfillRequest())
+    }
+
+    transacter.transaction { session ->
+      val run = session.load(Id<DbBackfillRun>(id))
+      assertThat(run.state).isEqualTo(BackfillState.RUNNING)
+      assertThat(run.approved_by_user).isEqualTo("diana")
+      assertThat(run.approved_at).isNotNull()
+    }
+  }
+
+  @Test
+  fun `required backfills fail closed for invalid persisted approvals`() {
+    val id = createApprovalBackfill(dryRun = true)
+    transacter.transaction { session ->
+      session.load(Id<DbBackfillRun>(id)).approved_by_user = "diana"
+    }
+    assertThatThrownBy {
+      scope.fakeCaller(user = "emma") {
+        startBackfillAction.start(id, StartBackfillRequest(approve = true))
+      }
+    }.isInstanceOf(BadRequestException::class.java)
+
+    transacter.transaction { session ->
+      val run = session.load(Id<DbBackfillRun>(id))
+      run.approved_by_user = "molly"
+      run.approved_at = Instant.parse("2020-01-01T00:00:00Z")
+    }
+    assertThatThrownBy {
+      scope.fakeCaller(user = "emma") {
+        startBackfillAction.start(id, StartBackfillRequest())
+      }
+    }.isInstanceOf(BadRequestException::class.java)
+  }
+
   @Test
   fun cantToggleCompletedBackfill() {
     scope.fakeCaller(service = "deep-fryer") {
@@ -558,6 +622,34 @@ class StartStopBackfillActionTest {
       assertThatThrownBy {
         stopBackfillAction.stop(id, StopBackfillRequest())
       }.isInstanceOf(BadRequestException::class.java)
+    }
+  }
+
+  private fun createApprovalBackfill(dryRun: Boolean): Long {
+    scope.fakeCaller(service = "deep-fryer") {
+      configureServiceAction.configureService(
+        ConfigureServiceRequest.Builder()
+          .backfills(
+            listOf(
+              ConfigureServiceRequest.BackfillData(
+                "ChickenSandwich", "Description", listOf(), null,
+                null, true, null, null,
+              ),
+            ),
+          )
+          .connector_type(Connectors.ENVOY)
+          .build(),
+      )
+    }
+    return scope.fakeCaller(user = "molly") {
+      createBackfillAction.create(
+        "deep-fryer",
+        RESERVED_VARIANT,
+        CreateBackfillRequest.Builder()
+          .backfill_name("ChickenSandwich")
+          .dry_run(dryRun)
+          .build(),
+      ).backfill_run_id
     }
   }
 }

--- a/service/src/test/kotlin/app/cash/backfila/api/CreateAndStartBackfillActionTest.kt
+++ b/service/src/test/kotlin/app/cash/backfila/api/CreateAndStartBackfillActionTest.kt
@@ -17,6 +17,7 @@ import misk.scope.ActionScope
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 
 @MiskTest(startService = true)
@@ -79,6 +80,37 @@ class CreateAndStartBackfillActionTest {
       assertThat(status.partitions[0].state).isEqualTo(BackfillState.RUNNING)
       assertThat(status.partitions[1].name).isEqualTo("80-")
       assertThat(status.partitions[1].state).isEqualTo(BackfillState.RUNNING)
+    }
+  }
+
+  @Test
+  fun `create and start cannot bypass required approval`() {
+    scope.fakeCaller(service = "deep-fryer") {
+      configureServiceAction.configureService(
+        ConfigureServiceRequest.Builder()
+          .backfills(
+            listOf(
+              ConfigureServiceRequest.BackfillData(
+                "ChickenSandwich", "Description", listOf(), null,
+                null, true, null, null,
+              ),
+            ),
+          )
+          .connector_type(Connectors.ENVOY)
+          .build(),
+      )
+
+      assertThatThrownBy {
+        createAndStartBackfillAction.createAndStartBackfill(
+          CreateAndStartBackfillRequest.Builder()
+            .create_request(
+              CreateBackfillRequest.Builder()
+                .backfill_name("ChickenSandwich")
+                .build(),
+            )
+            .build(),
+        )
+      }.isInstanceOf(misk.exceptions.BadRequestException::class.java)
     }
   }
 }


### PR DESCRIPTION
## Why
`requires_approval` and per-run approval fields are persisted today, but transitions to `RUNNING` do not enforce them. Approval-required backfills can therefore start through the dashboard, direct state toggler calls, or create-and-start without a second human.

## What
- Add an explicit `approve` field to the existing authenticated start request
- Atomically persist a distinct human approver and start the run
- Gate every required transition to `RUNNING`, including dry runs, wet runs, resumes, and create-and-start
- Reject missing, partial, or same-creator approval state and keep clones unapproved

## Risk Assessment
Medium — this changes the central run-state transition, but only registrations with `requires_approval` enabled are newly blocked. Backfills that do not require approval retain their current behavior.

Generated with Codex