### PR TITLE
Fix sparse-predicate batching in Jooq

### DIFF
--- a/client-jooq/src/main/kotlin/app/cash/backfila/client/jooq/internal/BatchRangeIterator.kt
+++ b/client-jooq/src/main/kotlin/app/cash/backfila/client/jooq/internal/BatchRangeIterator.kt
@@ -21,11 +21,12 @@ class BatchRangeIterator<K, Param : Any>(
 ) : AbstractIterator<GetNextBatchRangeResponse.Batch>() {
 
   private val timeElapsed: () -> Boolean
-  private var nextKeyRange: Lazy<OpenKeyRange<K>>
+  private var nextKeyRange: OpenKeyRange<K>
+  private var pendingWindow: PendingWindow<K>? = null
   init {
     timeElapsed =
       if (request.compute_time_limit_ms == null) { { false } } else timer(request.compute_time_limit_ms)
-    nextKeyRange = lazy { OpenKeyRange.initialRangeFor(jooqBackfill, request, session) }
+    nextKeyRange = OpenKeyRange.initialRangeFor(jooqBackfill, request, session)
   }
 
   private fun timer(timeLimitMs: Long): () -> Boolean {
@@ -35,16 +36,20 @@ class BatchRangeIterator<K, Param : Any>(
 
   override fun computeNext(): GetNextBatchRangeResponse.Batch? {
     if (timeElapsed() || request.backfill_range.start == null) return endOfData()
-    val keyRange = nextKeyRange.value
+    pendingWindow?.let {
+      nextKeyRange = OpenKeyRange.nextRangeFor(jooqBackfill, request, session, it.start)
+      pendingWindow = null
+    }
+    val keyRange = nextKeyRange
     val keyValues = selectKeyValues(keyRange)
     val end = keyRange.determineEnd(keyValues, request)
     val scannedCount = determineScannedCount(keyRange, end)
     if (scannedCount == 0) return endOfData()
     val start = keyRange.determineStart(session)
-    nextKeyRange = if (keyRange.endsAtUpperBound(end)) {
-      lazy { OpenKeyRange.nextRangeFor(jooqBackfill, request, session, end) }
+    if (keyRange.endsAtUpperBound(end)) {
+      pendingWindow = PendingWindow(end)
     } else {
-      lazyOf(keyRange.nextRangeFor(end))
+      nextKeyRange = keyRange.nextRangeFor(end)
     }
     return GetNextBatchRangeResponse.Batch.Builder()
       .batch_range(jooqBackfill.buildKeyRange(start, end))
@@ -78,3 +83,5 @@ class BatchRangeIterator<K, Param : Any>(
       ?: throw IllegalStateException("A SQL count will always return back a row")
   }
 }
+
+private class PendingWindow<K>(val start: K)

--- a/client-jooq/src/main/kotlin/app/cash/backfila/client/jooq/internal/BatchRangeIterator.kt
+++ b/client-jooq/src/main/kotlin/app/cash/backfila/client/jooq/internal/BatchRangeIterator.kt
@@ -21,11 +21,11 @@ class BatchRangeIterator<K, Param : Any>(
 ) : AbstractIterator<GetNextBatchRangeResponse.Batch>() {
 
   private val timeElapsed: () -> Boolean
-  private var nextKeyRange: OpenKeyRange<K>
+  private var nextKeyRange: Lazy<OpenKeyRange<K>>
   init {
     timeElapsed =
       if (request.compute_time_limit_ms == null) { { false } } else timer(request.compute_time_limit_ms)
-    nextKeyRange = OpenKeyRange.initialRangeFor(jooqBackfill, request, session)
+    nextKeyRange = lazy { OpenKeyRange.initialRangeFor(jooqBackfill, request, session) }
   }
 
   private fun timer(timeLimitMs: Long): () -> Boolean {
@@ -35,13 +35,17 @@ class BatchRangeIterator<K, Param : Any>(
 
   override fun computeNext(): GetNextBatchRangeResponse.Batch? {
     if (timeElapsed() || request.backfill_range.start == null) return endOfData()
-    val keyRange = nextKeyRange
+    val keyRange = nextKeyRange.value
     val keyValues = selectKeyValues(keyRange)
-    val start = keyRange.determineStart(keyValues)
-    val end = keyRange.determineEnd(keyValues)
+    val start = keyRange.determineStart(session)
+    val end = keyRange.determineEnd(keyValues, request)
     val scannedCount = determineScannedCount(keyRange, end)
     if (scannedCount == 0) return endOfData()
-    nextKeyRange = keyRange.nextRangeFor(end)
+    nextKeyRange = if (keyRange.endsAtUpperBound(end)) {
+      lazy { OpenKeyRange.nextRangeFor(jooqBackfill, request, session, end) }
+    } else {
+      lazyOf(keyRange.nextRangeFor(end))
+    }
     return GetNextBatchRangeResponse.Batch.Builder()
       .batch_range(jooqBackfill.buildKeyRange(start, end))
       .scanned_record_count(scannedCount.toLong())

--- a/client-jooq/src/main/kotlin/app/cash/backfila/client/jooq/internal/BatchRangeIterator.kt
+++ b/client-jooq/src/main/kotlin/app/cash/backfila/client/jooq/internal/BatchRangeIterator.kt
@@ -21,12 +21,11 @@ class BatchRangeIterator<K, Param : Any>(
 ) : AbstractIterator<GetNextBatchRangeResponse.Batch>() {
 
   private val timeElapsed: () -> Boolean
-  private var nextKeyRange: OpenKeyRange<K>
-  private var pendingWindow: PendingWindow<K>? = null
+  private var nextRange: NextRange<K>
   init {
     timeElapsed =
       if (request.compute_time_limit_ms == null) { { false } } else timer(request.compute_time_limit_ms)
-    nextKeyRange = OpenKeyRange.initialRangeFor(jooqBackfill, request, session)
+    nextRange = NextRange.WithinWindow(OpenKeyRange.initialRangeFor(jooqBackfill, request, session))
   }
 
   private fun timer(timeLimitMs: Long): () -> Boolean {
@@ -36,20 +35,20 @@ class BatchRangeIterator<K, Param : Any>(
 
   override fun computeNext(): GetNextBatchRangeResponse.Batch? {
     if (timeElapsed() || request.backfill_range.start == null) return endOfData()
-    pendingWindow?.let {
-      nextKeyRange = OpenKeyRange.nextRangeFor(jooqBackfill, request, session, it.start)
-      pendingWindow = null
+    val keyRange = when (val next = nextRange) {
+      is NextRange.WithinWindow -> next.range
+      is NextRange.NeedsNewWindow ->
+        OpenKeyRange.nextRangeFor(jooqBackfill, request, session, next.previousEnd)
     }
-    val keyRange = nextKeyRange
     val keyValues = selectKeyValues(keyRange)
     val end = keyRange.determineEnd(keyValues, request)
     val scannedCount = determineScannedCount(keyRange, end)
     if (scannedCount == 0) return endOfData()
     val start = keyRange.determineStart(session)
-    if (keyRange.endsAtUpperBound(end)) {
-      pendingWindow = PendingWindow(end)
+    nextRange = if (keyRange.endsAtUpperBound(end)) {
+      NextRange.NeedsNewWindow(end)
     } else {
-      nextKeyRange = keyRange.nextRangeFor(end)
+      NextRange.WithinWindow(keyRange.nextRangeFor(end))
     }
     return GetNextBatchRangeResponse.Batch.Builder()
       .batch_range(jooqBackfill.buildKeyRange(start, end))
@@ -84,4 +83,8 @@ class BatchRangeIterator<K, Param : Any>(
   }
 }
 
-private class PendingWindow<K>(val start: K)
+private sealed interface NextRange<K> {
+  class WithinWindow<K>(val range: OpenKeyRange<K>) : NextRange<K>
+
+  class NeedsNewWindow<K>(val previousEnd: K) : NextRange<K>
+}

--- a/client-jooq/src/main/kotlin/app/cash/backfila/client/jooq/internal/BatchRangeIterator.kt
+++ b/client-jooq/src/main/kotlin/app/cash/backfila/client/jooq/internal/BatchRangeIterator.kt
@@ -37,10 +37,10 @@ class BatchRangeIterator<K, Param : Any>(
     if (timeElapsed() || request.backfill_range.start == null) return endOfData()
     val keyRange = nextKeyRange.value
     val keyValues = selectKeyValues(keyRange)
-    val start = keyRange.determineStart(session)
     val end = keyRange.determineEnd(keyValues, request)
     val scannedCount = determineScannedCount(keyRange, end)
     if (scannedCount == 0) return endOfData()
+    val start = keyRange.determineStart(session)
     nextKeyRange = if (keyRange.endsAtUpperBound(end)) {
       lazy { OpenKeyRange.nextRangeFor(jooqBackfill, request, session, end) }
     } else {

--- a/client-jooq/src/main/kotlin/app/cash/backfila/client/jooq/internal/OpenKeyRange.kt
+++ b/client-jooq/src/main/kotlin/app/cash/backfila/client/jooq/internal/OpenKeyRange.kt
@@ -7,7 +7,6 @@ import app.cash.backfila.protos.clientservice.GetNextBatchRangeRequest
 import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Record
-import org.jooq.impl.DSL.select
 
 data class OpenKeyRange<K>(
   private val jooqBackfill: JooqBackfill<K, *>,
@@ -22,7 +21,7 @@ data class OpenKeyRange<K>(
    */
   private val start: K,
   /**
-   * The overall upper bound of the range.
+   * The upper bound of the current raw scan window.
    */
   private val upperBound: K,
 ) {
@@ -33,9 +32,33 @@ data class OpenKeyRange<K>(
   fun determineEnd(keyValues: List<K>): K =
     keyValues.lastOrNull() ?: upperBound
 
+  internal fun determineStart(session: DSLContext): K {
+    return session.select(jooqBackfill.compoundKeyFields)
+      .from(jooqBackfill.table)
+      .where(betweenStartAndUpperBoundCondition())
+      .orderBy(jooqBackfill.sortingByCompoundKeyFields { it.asc() })
+      .limit(1)
+      .fetchOne { jooqBackfill.recordToKey(it) }
+      ?: start
+  }
+
+  internal fun determineEnd(
+    keyValues: List<K>,
+    request: GetNextBatchRangeRequest,
+  ): K {
+    return if (request.precomputing == true || keyValues.size.toLong() < request.batch_size) {
+      upperBound
+    } else {
+      keyValues.last()
+    }
+  }
+
+  internal fun endsAtUpperBound(end: K): Boolean =
+    jooqBackfill.toByteString(end) == jooqBackfill.toByteString(upperBound)
+
   /**
-   * Builds a jooq condition that limits a query to the start of the range and the overall upper
-   * bound.
+   * Builds a jooq condition that limits a query to the start of the range and the current raw scan
+   * window's upper bound.
    */
   fun betweenStartAndUpperBoundCondition(): Condition {
     return jooqBackfill.compareCompoundKey(start, startComparison)
@@ -102,15 +125,57 @@ data class OpenKeyRange<K>(
           jooqBackfill.fromByteString(request.previous_end_key)
         } ?: jooqBackfill.fromByteString(request.backfill_range.start)
 
-      return OpenKeyRange(
+      return rangeFor(
         jooqBackfill = jooqBackfill,
+        request = request,
+        session = session,
         start = start,
         startComparison = startComparison,
-        upperBound = computeUpperBound(
-          jooqBackfill, request, session,
-          jooqBackfill.compareCompoundKey(start, startComparison),
-        ),
       )
+    }
+
+    internal fun <K> nextRangeFor(
+      jooqBackfill: JooqBackfill<K, *>,
+      request: GetNextBatchRangeRequest,
+      session: DSLContext,
+      start: K,
+    ): OpenKeyRange<K> {
+      return rangeFor(
+        jooqBackfill = jooqBackfill,
+        request = request,
+        session = session,
+        start = start,
+        startComparison = { keyComparer, compoundKeyValue ->
+          keyComparer.gt(compoundKeyValue)
+        },
+      )
+    }
+
+    private fun <K> rangeFor(
+      jooqBackfill: JooqBackfill<K, *>,
+      request: GetNextBatchRangeRequest,
+      session: DSLContext,
+      start: K,
+      startComparison: CompoundKeyComparisonOperator<K>,
+    ): OpenKeyRange<K> {
+      val upperBound = computeUpperBound(
+        jooqBackfill = jooqBackfill,
+        request = request,
+        session = session,
+        afterPrecedingRowsCondition = jooqBackfill.compareCompoundKey(start, startComparison),
+      )
+      return if (upperBound != null) {
+        OpenKeyRange(jooqBackfill, startComparison, start, upperBound)
+      } else {
+        OpenKeyRange(
+          jooqBackfill = jooqBackfill,
+          startComparison = { keyComparer, compoundKeyValue ->
+            keyComparer.gt(compoundKeyValue)
+          },
+          start = start,
+          upperBound = start,
+        )
+      }
     }
 
     /**
@@ -136,27 +201,33 @@ data class OpenKeyRange<K>(
       jooqBackfill: JooqBackfill<K, *>,
       request: GetNextBatchRangeRequest,
       session: DSLContext,
-      afterPreceedingRowsCondition: Condition,
-    ): K {
-      return if (request.backfill_range != null && request.backfill_range.end != null) {
-        jooqBackfill.fromByteString(request.backfill_range.end)
-      } else {
-        session
-          .select(jooqBackfill.compoundKeyFields)
-          .from(
-            select(jooqBackfill.compoundKeyFields)
-              .from(jooqBackfill.table)
-              .where(afterPreceedingRowsCondition)
-              .orderBy(jooqBackfill.sortingByCompoundKeyFields { it.asc() })
-              .limit(request.scan_size),
-          )
-          .orderBy(jooqBackfill.sortingByCompoundKeyFields { it.desc() })
-          .limit(1)
-          .fetchOne { jooqBackfill.recordToKey(it) }
-          ?: throw IllegalStateException(
-            "Expecting a row when calculating the upper bound",
-          )
+      afterPrecedingRowsCondition: Condition,
+    ): K? {
+      val overallEnd = request.backfill_range?.end?.let(jooqBackfill::fromByteString)
+      val boundedCondition = overallEnd?.let {
+        afterPrecedingRowsCondition.and(
+          jooqBackfill.compareCompoundKey(it) { keyCompare, compoundKeyValue ->
+            keyCompare.lte(compoundKeyValue)
+          },
+        )
+      } ?: afterPrecedingRowsCondition
+      val scanWindow = session
+        .select(jooqBackfill.compoundKeyFields)
+        .from(jooqBackfill.table)
+        .where(boundedCondition)
+        .orderBy(jooqBackfill.sortingByCompoundKeyFields { it.asc() })
+        .limit(request.scan_size)
+        .asTable("scan_window")
+      val scanWindowFields = jooqBackfill.compoundKeyFields.map { field ->
+        checkNotNull(scanWindow.field(field))
       }
+
+      return session
+        .select(scanWindowFields)
+        .from(scanWindow)
+        .orderBy(scanWindowFields.map { it.desc() })
+        .limit(1)
+        .fetchOne { jooqBackfill.recordToKey(it) }
     }
   }
 }

--- a/client-jooq/src/test/kotlin/app/cash/backfila/client/jooq/MiskJooqBackfillTests.kt
+++ b/client-jooq/src/test/kotlin/app/cash/backfila/client/jooq/MiskJooqBackfillTests.kt
@@ -225,10 +225,14 @@ class MiskJooqBackfillTests {
 
     assertThat(batches).hasSize(4)
     assertThat(batches).allMatch { it.scanned_record_count <= run.scanSize }
+    // Batches: [0..1] full match, [2..3] empty tail, [4..7] empty window, and
+    // [8..11] sparse full match.
     assertThat(batches.map { it.scanned_record_count }).containsExactly(2L, 2L, 4L, 4L)
     assertThat(batches.map { it.matching_record_count }).containsExactly(2L, 0L, 0L, 2L)
+    // The first window's empty tail starts after the preceding matching batch.
     assertThat(batches[1].batch_range.start.utf8()).isEqualTo(rawKeys[2].toString())
     assertThat(batches[1].batch_range.end.utf8()).isEqualTo(rawKeys[3].toString())
+    // The entirely empty second window still advances the raw cursor.
     assertThat(batches[2].batch_range.start.utf8()).isEqualTo(rawKeys[4].toString())
     assertThat(batches[2].batch_range.end.utf8()).isEqualTo(rawKeys[7].toString())
 

--- a/client-jooq/src/test/kotlin/app/cash/backfila/client/jooq/MiskJooqBackfillTests.kt
+++ b/client-jooq/src/test/kotlin/app/cash/backfila/client/jooq/MiskJooqBackfillTests.kt
@@ -194,7 +194,7 @@ class MiskJooqBackfillTests {
 
   @Test
   fun sparseMatchesStayWithinRawScanWindows() {
-    val matchingPositions = listOf(0, 3, 8, 11)
+    val matchingPositions = listOf(0, 1, 8, 11)
     val rawKeys = transacter.transaction("sparseMatchesStayWithinRawScanWindows") { session ->
       (0 until 12).map { position ->
         session.newRecord(MENU)
@@ -220,12 +220,14 @@ class MiskJooqBackfillTests {
 
     val batches = run.singleScan().batches
 
-    assertThat(batches).hasSize(3)
+    assertThat(batches).hasSize(4)
     assertThat(batches).allMatch { it.scanned_record_count <= run.scanSize }
-    assertThat(batches.map { it.scanned_record_count }).containsExactly(4L, 4L, 4L)
-    assertThat(batches.map { it.matching_record_count }).containsExactly(2L, 0L, 2L)
-    assertThat(batches[1].batch_range.start.utf8()).isEqualTo(rawKeys[4].toString())
-    assertThat(batches[1].batch_range.end.utf8()).isEqualTo(rawKeys[7].toString())
+    assertThat(batches.map { it.scanned_record_count }).containsExactly(2L, 2L, 4L, 4L)
+    assertThat(batches.map { it.matching_record_count }).containsExactly(2L, 0L, 0L, 2L)
+    assertThat(batches[1].batch_range.start.utf8()).isEqualTo(rawKeys[2].toString())
+    assertThat(batches[1].batch_range.end.utf8()).isEqualTo(rawKeys[3].toString())
+    assertThat(batches[2].batch_range.start.utf8()).isEqualTo(rawKeys[4].toString())
+    assertThat(batches[2].batch_range.end.utf8()).isEqualTo(rawKeys[7].toString())
 
     run.scanRemaining()
     run.runAllScanned()

--- a/client-jooq/src/test/kotlin/app/cash/backfila/client/jooq/MiskJooqBackfillTests.kt
+++ b/client-jooq/src/test/kotlin/app/cash/backfila/client/jooq/MiskJooqBackfillTests.kt
@@ -1,11 +1,14 @@
 package app.cash.backfila.client.jooq
 
 import app.cash.backfila.client.jooq.config.ClientJooqTestingModule
+import app.cash.backfila.client.jooq.config.CompoundKey
 import app.cash.backfila.client.jooq.config.IdRecorder
 import app.cash.backfila.client.jooq.config.JooqDBIdentifier
 import app.cash.backfila.client.jooq.config.JooqMenuTestBackfill
 import app.cash.backfila.client.jooq.config.JooqTransacter
+import app.cash.backfila.client.jooq.config.JooqWidgetCompoundKeyBackfill
 import app.cash.backfila.client.jooq.gen.tables.references.MENU
+import app.cash.backfila.client.jooq.gen.tables.references.WIDGETS
 import app.cash.backfila.client.testing.assertThat as testingAssertThat
 import app.cash.backfila.embedded.Backfila
 import app.cash.backfila.embedded.BackfillRun
@@ -228,6 +231,57 @@ class MiskJooqBackfillTests {
     assertThat(batches[1].batch_range.end.utf8()).isEqualTo(rawKeys[3].toString())
     assertThat(batches[2].batch_range.start.utf8()).isEqualTo(rawKeys[4].toString())
     assertThat(batches[2].batch_range.end.utf8()).isEqualTo(rawKeys[7].toString())
+
+    run.scanRemaining()
+    run.runAllScanned()
+
+    assertThat(run.backfill.idsRanDry).containsExactlyElementsOf(expectedMatchingKeys)
+  }
+
+  @Test
+  fun compoundKeySparseMatchesStayWithinRawScanWindows() {
+    val matchingPositions = listOf(0, 1, 8, 9, 10, 11)
+    val rawKeys = transacter.transaction("compoundKeySparseMatchesStayWithinRawScanWindows") { session ->
+      (0 until 12).map { position ->
+        session.newRecord(WIDGETS)
+          .apply {
+            name = if (position in matchingPositions) "chicken" else "beef"
+            manufacturerToken = when (position) {
+              in 0..1 -> "token1 - select for backfill"
+              in 2..7 -> "token2 - not select for backfill"
+              else -> "token3 - select for backfill"
+            }
+            createdAtMs = clock.instant().toEpochMilli() + position / 2
+            widgetToken = "widget-${position.toString().padStart(2, '0')}".encodeToByteArray()
+          }.let {
+            it.store()
+            CompoundKey.recordToKey(it)
+          }
+      }
+    }
+    val expectedMatchingKeys = matchingPositions.map(rawKeys::get)
+    val run = backfila.createDryRun(
+      JooqWidgetCompoundKeyBackfill::class,
+      emptyMap(),
+      null,
+      null,
+    ).apply {
+      batchSize = 2
+      scanSize = 4
+      computeCountLimit = 10
+    }
+
+    val batches = run.singleScan().batches
+
+    assertThat(batches).hasSize(5)
+    assertThat(batches).allMatch { it.scanned_record_count <= run.scanSize }
+    assertThat(batches.map { it.scanned_record_count }).containsExactly(2L, 2L, 4L, 2L, 2L)
+    assertThat(batches.map { it.matching_record_count }).containsExactly(2L, 0L, 0L, 2L, 2L)
+    assertThat(batches[1].batch_range.start.utf8()).isEqualTo(rawKeys[2].toString())
+    assertThat(batches[1].batch_range.end.utf8()).isEqualTo(rawKeys[3].toString())
+    assertThat(batches[2].batch_range.start.utf8()).isEqualTo(rawKeys[4].toString())
+    assertThat(batches[2].batch_range.end.utf8()).isEqualTo(rawKeys[7].toString())
+    assertThat(batches.last().batch_range.end.utf8()).isEqualTo(rawKeys[11].toString())
 
     run.scanRemaining()
     run.runAllScanned()

--- a/client-jooq/src/test/kotlin/app/cash/backfila/client/jooq/MiskJooqBackfillTests.kt
+++ b/client-jooq/src/test/kotlin/app/cash/backfila/client/jooq/MiskJooqBackfillTests.kt
@@ -5,6 +5,7 @@ import app.cash.backfila.client.jooq.config.IdRecorder
 import app.cash.backfila.client.jooq.config.JooqDBIdentifier
 import app.cash.backfila.client.jooq.config.JooqMenuTestBackfill
 import app.cash.backfila.client.jooq.config.JooqTransacter
+import app.cash.backfila.client.jooq.gen.tables.references.MENU
 import app.cash.backfila.client.testing.assertThat as testingAssertThat
 import app.cash.backfila.embedded.Backfila
 import app.cash.backfila.embedded.BackfillRun
@@ -189,6 +190,47 @@ class MiskJooqBackfillTests {
     testingAssertThat(run).isComplete()
     assertThat(run.backfill.idsRanDry).containsExactlyElementsOf(backfillRowKeys)
     assertThat(run.backfill.idsRanWet).isEmpty()
+  }
+
+  @Test
+  fun sparseMatchesStayWithinRawScanWindows() {
+    val matchingPositions = listOf(0, 3, 8, 11)
+    val rawKeys = transacter.transaction("sparseMatchesStayWithinRawScanWindows") { session ->
+      (0 until 12).map { position ->
+        session.newRecord(MENU)
+          .apply {
+            name = if (position in matchingPositions) "chicken" else "beef"
+          }.let {
+            it.store()
+            it.id!!
+          }
+      }
+    }
+    val expectedMatchingKeys = matchingPositions.map(rawKeys::get)
+    val run = backfila.createDryRun(
+      JooqMenuTestBackfill::class,
+      emptyMap(),
+      null,
+      null,
+    ).apply {
+      batchSize = 2
+      scanSize = 4
+      computeCountLimit = 10
+    }
+
+    val batches = run.singleScan().batches
+
+    assertThat(batches).hasSize(3)
+    assertThat(batches).allMatch { it.scanned_record_count <= run.scanSize }
+    assertThat(batches.map { it.scanned_record_count }).containsExactly(4L, 4L, 4L)
+    assertThat(batches.map { it.matching_record_count }).containsExactly(2L, 0L, 2L)
+    assertThat(batches[1].batch_range.start.utf8()).isEqualTo(rawKeys[4].toString())
+    assertThat(batches[1].batch_range.end.utf8()).isEqualTo(rawKeys[7].toString())
+
+    run.scanRemaining()
+    run.runAllScanned()
+
+    assertThat(run.backfill.idsRanDry).containsExactlyElementsOf(expectedMatchingKeys)
   }
 
   @ParameterizedTest(name = "precomputingIgnoresBatchSize test - {0}")


### PR DESCRIPTION
## Summary

Fixes sparse-predicate batching in the jOOQ client by bounding work with an unfiltered raw-key window of at most `scan_size` rows before applying the backfill predicate.

## Problem

Prepared jOOQ backfills normally provide an overall range end. `OpenKeyRange` previously used that value directly, bypassing its `LIMIT scan_size` path.

`BatchRangeIterator` would then:

1. Find up to `batch_size` matching keys.
2. Use the first and last matches as the batch range.
3. **Run an unfiltered `COUNT(*)` across that raw-key interval.** This times out for large tables.

For sparse predicates, a few matching rows can span millions of raw IDs. Although `LIMIT batch_size` bounds matching rows, it does not bound the subsequent count.

## Approach

The new batching flow mirrors Hibernate Backfila’s two-level model:

1. Select the next `scan_size` raw keys without applying the backfill predicate, capped by the overall range end.
2. Apply the predicate only within that raw-key window.
3. End a full batch at its `batch_size`th match.
4. Extend partial or empty batches to the raw window’s upper bound.
5. Continue within the same window when a full batch ends early; otherwise advance to a new raw window.

This guarantees every emitted raw range contains at most `scan_size` rows, including windows where no rows match.

For example, with `scan_size = 4`, `batch_size = 2`, and matches at positions `0, 1, 8, 11`:

| Batch | Raw range | Scanned | Matching |
|---|---:|---:|---:|
| Full batch | `0..1` | 2 | 2 |
| Empty window remainder | `2..3` | 2 | 0 |
| Entirely empty window | `4..7` | 4 | 0 |
| Sparse full batch | `8..11` | 4 | 2 |

`scan_size` is a ceiling rather than a target: a batch can end earlier when it reaches `batch_size` matches.

## Implementation details

- Builds each raw window using an ordered, unfiltered `LIMIT scan_size` query.
- Remaps compound-key fields to the derived scan-window table before selecting its maximum key.
- Determines the first real raw key separately so inclusive batch ranges do not replay the preceding match.
- Defers computing the next raw window until another batch is requested, avoiding unnecessary queries when the compute limit is reached.
- Preserves the existing public `OpenKeyRange` API and precomputation behavior.

## Regression coverage

Adds scalar- and compound-key sparse-predicate tests that verify:

- No emitted raw range exceeds `scan_size`.
- Empty raw windows and empty window tails advance correctly.
- Matching rows are processed exactly once without skips or duplicates.
- Compound-key ordering works when the first two key fields tie and the binary final field determines ordering.