### PR TITLE
fix(service): key Edit Cursor on partition id so it works for any partition name

### DIFF
--- a/service/api/service.api
+++ b/service/api/service.api
@@ -201,21 +201,22 @@ public final class app/cash/backfila/dashboard/CreateBackfillAction : misk/web/a
 public final class app/cash/backfila/dashboard/EditPartitionCursorAction : misk/web/actions/WebAction {
 	public static final field Companion Lapp/cash/backfila/dashboard/EditPartitionCursorAction$Companion;
 	public fun <init> (Lapp/cash/backfila/dashboard/GetBackfillStatusAction;Lapp/cash/backfila/ui/components/DashboardPageLayout;)V
-	public final fun get (JLjava/lang/String;)Lmisk/web/Response;
+	public final fun get (JJ)Lmisk/web/Response;
 }
 
 public final class app/cash/backfila/dashboard/EditPartitionCursorAction$Companion {
-	public final fun path (JLjava/lang/String;)Ljava/lang/String;
+	public final fun path (JJ)Ljava/lang/String;
 }
 
 public final class app/cash/backfila/dashboard/EditPartitionCursorHandlerAction : misk/web/actions/WebAction {
 	public static final field Companion Lapp/cash/backfila/dashboard/EditPartitionCursorHandlerAction$Companion;
-	public fun <init> (Lapp/cash/backfila/dashboard/GetBackfillStatusAction;Lmisk/hibernate/Transacter;Lmisk/hibernate/Query$Factory;Lmisk/scope/ActionScoped;Lapp/cash/backfila/ui/components/DashboardPageLayout;)V
-	public final fun get (JLjava/lang/String;)Lmisk/web/Response;
+	public fun <init> (Lapp/cash/backfila/dashboard/GetBackfillStatusAction;Lmisk/hibernate/Transacter;Lmisk/hibernate/Query$Factory;Lapp/cash/backfila/ui/components/DashboardPageLayout;)V
+	public final fun get (JJLjava/lang/String;Ljava/lang/String;)Lmisk/web/Response;
+	public static synthetic fun get$default (Lapp/cash/backfila/dashboard/EditPartitionCursorHandlerAction;JJLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lmisk/web/Response;
 }
 
 public final class app/cash/backfila/dashboard/EditPartitionCursorHandlerAction$Companion {
-	public final fun path (JLjava/lang/String;)Ljava/lang/String;
+	public final fun path (JJ)Ljava/lang/String;
 }
 
 public final class app/cash/backfila/dashboard/GetBackfillRunsAction : misk/web/actions/WebAction {
@@ -1013,7 +1014,7 @@ public abstract interface class app/cash/backfila/service/persistence/RunPartiti
 	public abstract fun backfillRunIdIn (Ljava/util/Collection;)Lapp/cash/backfila/service/persistence/RunPartitionQuery;
 	public abstract fun leaseExpiresAtBefore (Ljava/time/Instant;)Lapp/cash/backfila/service/persistence/RunPartitionQuery;
 	public abstract fun orderByName ()Lapp/cash/backfila/service/persistence/RunPartitionQuery;
-	public abstract fun partitionId (J)Lapp/cash/backfila/service/persistence/RunPartitionQuery;
+	public abstract fun partitionId (Lmisk/hibernate/Id;)Lapp/cash/backfila/service/persistence/RunPartitionQuery;
 	public abstract fun runState (Lapp/cash/backfila/service/persistence/BackfillState;)Lapp/cash/backfila/service/persistence/RunPartitionQuery;
 }
 

--- a/service/src/main/kotlin/app/cash/backfila/dashboard/EditPartitionCursorAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/dashboard/EditPartitionCursorAction.kt
@@ -15,6 +15,7 @@ import kotlinx.html.h1
 import kotlinx.html.input
 import kotlinx.html.label
 import kotlinx.html.p
+import misk.exceptions.BadRequestException
 import misk.security.authz.Authenticated
 import misk.tailwind.Link
 import misk.web.Get
@@ -36,14 +37,14 @@ class EditPartitionCursorAction @Inject constructor(
   @Authenticated(capabilities = ["users"])
   fun get(
     @PathParam id: Long,
-    @PathParam partitionName: String,
+    @PathParam partitionId: Long,
   ): Response<ResponseBody> {
     val backfill = getBackfillStatusAction.status(id)
 
-    val partition = backfill.partitions.find { it.name == partitionName }
-      ?: throw IllegalArgumentException("Partition not found")
+    val partition = backfill.partitions.find { it.id == partitionId }
+      ?: throw BadRequestException("Partition $partitionId not found in backfill $id")
 
-    // Take a snapshot of current cursor for validation
+    val partitionName = partition.name
     val cursorSnapshot = partition.pkey_cursor
 
     return Response(
@@ -51,7 +52,7 @@ class EditPartitionCursorAction @Inject constructor(
         .title("Edit Cursor - Partition $partitionName")
         .breadcrumbLinks(
           Link("Backfill #$id", BackfillShowAction.path(id)),
-          Link("Edit Cursor", path(id, partitionName)),
+          Link("Edit Cursor", path(id, partitionId)),
         )
         .buildHtmlResponseBody {
           div("space-y-6 max-w-2xl mx-auto py-8") {
@@ -82,7 +83,7 @@ class EditPartitionCursorAction @Inject constructor(
 
             form {
               method = FormMethod.get
-              action = EditPartitionCursorHandlerAction.path(id, partitionName)
+              action = EditPartitionCursorHandlerAction.path(id, partitionId)
 
               input {
                 type = InputType.hidden
@@ -121,7 +122,7 @@ class EditPartitionCursorAction @Inject constructor(
                     }
                   }
                   p("mt-2 text-sm text-gray-500") {
-                    +"Enter the new cursor value. This must be a valid UTF-8 string."
+                    +"Enter the new cursor value. It cannot be empty."
                   }
                 }
 
@@ -142,9 +143,9 @@ class EditPartitionCursorAction @Inject constructor(
   }
 
   companion object {
-    private const val PATH = "/backfills/{id}/{partitions}/{partitionName}/edit-cursor"
-    fun path(id: Long, partitionName: String) = PATH
+    private const val PATH = "/backfills/{id}/partitions/{partitionId}/edit-cursor"
+    fun path(id: Long, partitionId: Long) = PATH
       .replace("{id}", id.toString())
-      .replace("{partitionName}", partitionName)
+      .replace("{partitionId}", partitionId.toString())
   }
 }

--- a/service/src/main/kotlin/app/cash/backfila/dashboard/EditPartitionCursorHandlerAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/dashboard/EditPartitionCursorHandlerAction.kt
@@ -10,14 +10,14 @@ import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import kotlinx.html.div
 import misk.exceptions.BadRequestException
+import misk.hibernate.Id
 import misk.hibernate.Query
 import misk.hibernate.Transacter
 import misk.hibernate.newQuery
-import misk.scope.ActionScoped
 import misk.security.authz.Authenticated
 import misk.web.Get
-import misk.web.HttpCall
 import misk.web.PathParam
+import misk.web.QueryParam
 import misk.web.Response
 import misk.web.ResponseBody
 import misk.web.ResponseContentType
@@ -32,7 +32,6 @@ class EditPartitionCursorHandlerAction @Inject constructor(
   private val getBackfillStatusAction: GetBackfillStatusAction,
   @BackfilaDb private val transacter: Transacter,
   private val queryFactory: Query.Factory,
-  private val httpCall: ActionScoped<HttpCall>,
   private val dashboardPageLayout: DashboardPageLayout,
 ) : WebAction {
 
@@ -41,35 +40,31 @@ class EditPartitionCursorHandlerAction @Inject constructor(
   @Authenticated(capabilities = ["users"])
   fun get(
     @PathParam id: Long,
-    @PathParam partitionName: String,
+    @PathParam partitionId: Long,
+    @QueryParam cursor_snapshot: String? = null,
+    @QueryParam new_cursor: String? = null,
   ): Response<ResponseBody> {
-    val request = httpCall.get().asOkHttpRequest()
-    val cursorSnapshot = request.url.queryParameter("cursor_snapshot")?.takeIf { it.isNotBlank() }
-    val newCursor = request.url.queryParameter("new_cursor")
-
-    if (!isValidUtf8(newCursor)) {
-      return buildErrorResponse("New cursor must be valid UTF8. New Cursor: $newCursor")
-    }
+    val cursorSnapshot = cursor_snapshot?.takeIf { it.isNotBlank() }
+    val newCursor = new_cursor?.takeIf { it.isNotBlank() }
+      ?: return buildErrorResponse("New cursor is required.")
 
     val backfill = getBackfillStatusAction.status(id)
     if (backfill.state != BackfillState.PAUSED) {
       return buildErrorResponse("Backfill must be paused. Current State: ${backfill.state}")
     }
 
-    val partition = backfill.partitions.find { it.name == partitionName }
-      ?: return buildErrorResponse("Partition not found: $partitionName")
+    val partition = backfill.partitions.find { it.id == partitionId }
+      ?: return buildErrorResponse("Partition $partitionId not found in backfill $id")
 
-    if (partition.pkey_cursor != cursorSnapshot) {
-      return buildErrorResponse("Cursor has changed since edit form was loaded. Current Cursor: ${partition.pkey_cursor}")
+    return when (compareAndSetCursor(id, partitionId, cursorSnapshot, newCursor)) {
+      CursorUpdate.UPDATED -> redirectToBackfillPage(id)
+      CursorUpdate.CURSOR_NOT_UTF8 -> buildErrorResponse(
+        "Partition ${partition.name} has a cursor that is not valid UTF-8, so it cannot be edited here.",
+      )
+      CursorUpdate.SNAPSHOT_STALE -> buildErrorResponse(
+        "Cursor has changed since edit form was loaded. Current Cursor: ${partition.pkey_cursor}",
+      )
     }
-
-    updateCursor(partition.id, newCursor)
-
-    return redirectToBackfillPage(id)
-  }
-
-  private fun isValidUtf8(input: String?): Boolean {
-    return input == null || input.toByteArray(Charsets.UTF_8).contentEquals(input.toByteArray(Charsets.UTF_8))
   }
 
   private fun buildErrorResponse(message: String): Response<ResponseBody> {
@@ -86,17 +81,31 @@ class EditPartitionCursorHandlerAction @Inject constructor(
     )
   }
 
-  private fun updateCursor(partitionId: Long, newCursor: String?) {
-    transacter.transaction { session ->
-      queryFactory.newQuery<RunPartitionQuery>()
-        .partitionId(partitionId)
-        .uniqueResult(session)
-        ?.let { partitionRecord ->
-          partitionRecord.pkey_cursor = newCursor?.encodeUtf8()
-          session.save(partitionRecord)
-        } ?: throw BadRequestException("Partition not found")
+  /** The form round-trips the snapshot through `utf8()`, so bytes that are not UTF-8 cannot be compared. */
+  private fun compareAndSetCursor(
+    id: Long,
+    partitionId: Long,
+    cursorSnapshot: String?,
+    newCursor: String,
+  ): CursorUpdate = transacter.transaction { session ->
+    val partitionRecord = queryFactory.newQuery<RunPartitionQuery>()
+      .backfillRunId(Id(id))
+      .partitionId(Id(partitionId))
+      .uniqueResult(session)
+      ?: throw BadRequestException("Partition $partitionId not found in backfill $id")
+
+    val storedCursor = partitionRecord.pkey_cursor
+    if (storedCursor != null && storedCursor.utf8().encodeUtf8() != storedCursor) {
+      return@transaction CursorUpdate.CURSOR_NOT_UTF8
     }
+    if (storedCursor != cursorSnapshot?.encodeUtf8()) {
+      return@transaction CursorUpdate.SNAPSHOT_STALE
+    }
+    partitionRecord.pkey_cursor = newCursor.encodeUtf8()
+    CursorUpdate.UPDATED
   }
+
+  private enum class CursorUpdate { UPDATED, SNAPSHOT_STALE, CURSOR_NOT_UTF8 }
 
   private fun redirectToBackfillPage(id: Long): Response<ResponseBody> {
     return Response(
@@ -107,10 +116,10 @@ class EditPartitionCursorHandlerAction @Inject constructor(
   }
 
   companion object {
-    private const val PATH = "/backfills/{id}/{partitionName}/edit-cursor"
+    private const val PATH = "/api/backfill/{id}/partitions/{partitionId}/cursor"
 
-    fun path(id: Long, partitionName: String) = PATH
+    fun path(id: Long, partitionId: Long) = PATH
       .replace("{id}", id.toString())
-      .replace("{partitionName}", partitionName)
+      .replace("{partitionId}", partitionId.toString())
   }
 }

--- a/service/src/main/kotlin/app/cash/backfila/service/persistence/RunPartitionQuery.kt
+++ b/service/src/main/kotlin/app/cash/backfila/service/persistence/RunPartitionQuery.kt
@@ -24,5 +24,5 @@ interface RunPartitionQuery : Query<DbRunPartition> {
   fun orderByName(): RunPartitionQuery
 
   @Constraint("id", Operator.EQ)
-  fun partitionId(partitionId: Long): RunPartitionQuery
+  fun partitionId(partitionId: Id<DbRunPartition>): RunPartitionQuery
 }

--- a/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/pages/BackfillShowAction.kt
@@ -381,7 +381,7 @@ class BackfillShowAction @Inject constructor(
                       if (backfill.state == BackfillState.PAUSED) {
                         td("py-5 pl-8 pr-0 text-right align-top") {
                           a(
-                            href = EditPartitionCursorAction.path(id, partition.name),
+                            href = EditPartitionCursorAction.path(id, partition.id),
                             classes = "text-indigo-600 hover:text-indigo-900",
                           ) {
                             +"Edit Cursor"

--- a/service/src/test/kotlin/app/cash/backfila/actions/EditPartitionCursorActionTest.kt
+++ b/service/src/test/kotlin/app/cash/backfila/actions/EditPartitionCursorActionTest.kt
@@ -1,0 +1,282 @@
+package app.cash.backfila.actions
+
+import app.cash.backfila.BackfilaTestingModule
+import app.cash.backfila.api.ConfigureServiceAction
+import app.cash.backfila.api.ConfigureServiceAction.Companion.RESERVED_VARIANT
+import app.cash.backfila.client.Connectors
+import app.cash.backfila.client.FakeBackfilaCallbackConnector
+import app.cash.backfila.dashboard.CreateBackfillAction
+import app.cash.backfila.dashboard.EditPartitionCursorAction
+import app.cash.backfila.dashboard.EditPartitionCursorHandlerAction
+import app.cash.backfila.dashboard.GetBackfillStatusAction
+import app.cash.backfila.fakeCaller
+import app.cash.backfila.protos.clientservice.KeyRange
+import app.cash.backfila.protos.clientservice.PrepareBackfillResponse
+import app.cash.backfila.protos.service.ConfigureServiceRequest
+import app.cash.backfila.protos.service.CreateBackfillRequest
+import app.cash.backfila.service.persistence.BackfilaDb
+import app.cash.backfila.service.persistence.RunPartitionQuery
+import com.google.inject.Module
+import jakarta.inject.Inject
+import javax.servlet.http.HttpServletRequest
+import misk.Action
+import misk.MiskCaller
+import misk.api.HttpRequest
+import misk.exceptions.BadRequestException
+import misk.hibernate.Id
+import misk.hibernate.Query
+import misk.hibernate.Transacter
+import misk.hibernate.newQuery
+import misk.inject.KAbstractModule
+import misk.inject.keyOf
+import misk.inject.toKey
+import misk.scope.ActionScope
+import misk.scope.ActionScopedProviderModule
+import misk.security.authz.MiskCallerAuthenticator
+import misk.testing.MiskTest
+import misk.testing.MiskTestModule
+import misk.web.FakeHttpCall
+import misk.web.HttpCall
+import misk.web.dashboard.BaseDashboardModule
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okio.ByteString
+import okio.ByteString.Companion.encodeUtf8
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+@MiskTest(startService = true)
+class EditPartitionCursorActionTest {
+  @Suppress("unused")
+  @MiskTestModule
+  val module: Module = TestModule()
+
+  @Inject
+  lateinit var configureServiceAction: ConfigureServiceAction
+
+  @Inject
+  lateinit var createBackfillAction: CreateBackfillAction
+
+  @Inject
+  lateinit var getBackfillStatusAction: GetBackfillStatusAction
+
+  @Inject
+  lateinit var editPartitionCursorAction: EditPartitionCursorAction
+
+  @Inject
+  lateinit var editPartitionCursorHandlerAction: EditPartitionCursorHandlerAction
+
+  @Inject
+  lateinit var fakeBackfilaClientServiceClient: FakeBackfilaCallbackConnector
+
+  @Inject
+  lateinit var scope: ActionScope
+
+  @Inject
+  lateinit var queryFactory: Query.Factory
+
+  @Inject
+  @BackfilaDb
+  lateinit var transacter: Transacter
+
+  @Test
+  fun `paths never interpolate the partition name`() {
+    assertThat(EditPartitionCursorAction.path(24852L, 77568L))
+      .isEqualTo("/backfills/24852/partitions/77568/edit-cursor")
+    assertThat(EditPartitionCursorHandlerAction.path(24852L, 77568L))
+      .isEqualTo("/api/backfill/24852/partitions/77568/cursor")
+  }
+
+  @Test
+  fun `form page renders for a partition whose name is not url safe`() {
+    val id = createPausedBackfill("region-shard-us-east#orders_local_ro_0")
+
+    inScope {
+      val partitionId = onlyPartitionId(id)
+
+      assertThat(editPartitionCursorAction.get(id, partitionId).statusCode).isEqualTo(200)
+
+      assertThatThrownBy { editPartitionCursorAction.get(id, partitionId + 1000) }
+        .isInstanceOf(BadRequestException::class.java)
+    }
+  }
+
+  @Test
+  fun `edits a partition whose name is not url safe`() {
+    val id = createPausedBackfill("region-shard-us-east#orders_local_ro_0")
+
+    inScope {
+      val partitionId = onlyPartitionId(id)
+      assertThat(cursorOf(id)).isNull()
+
+      val response = editPartitionCursorHandlerAction.get(id, partitionId, "", "1079486")
+
+      assertThat(response.statusCode).isEqualTo(303)
+      assertThat(cursorOf(id)).isEqualTo("1079486")
+    }
+  }
+
+  @Test
+  fun `edits a partition using the matching non null snapshot the form submits`() {
+    val id = createPausedBackfill("only")
+
+    inScope {
+      val partitionId = onlyPartitionId(id)
+      editPartitionCursorHandlerAction.get(id, partitionId, "", "500")
+
+      val response = editPartitionCursorHandlerAction.get(id, partitionId, "500", "9000")
+
+      assertThat(response.statusCode).isEqualTo(303)
+      assertThat(cursorOf(id)).isEqualTo("9000")
+    }
+  }
+
+  @Test
+  fun `rejects a stale snapshot`() {
+    val id = createPausedBackfill("only")
+
+    inScope {
+      val partitionId = onlyPartitionId(id)
+      editPartitionCursorHandlerAction.get(id, partitionId, "", "500")
+
+      val response = editPartitionCursorHandlerAction.get(id, partitionId, "499", "9000")
+
+      assertThat(response.statusCode).isEqualTo(200)
+      assertThat(cursorOf(id)).isEqualTo("500")
+    }
+  }
+
+  @Test
+  fun `a missing new cursor does not clear the cursor`() {
+    val id = createPausedBackfill("only")
+
+    inScope {
+      val partitionId = onlyPartitionId(id)
+      editPartitionCursorHandlerAction.get(id, partitionId, "", "500")
+
+      val response = editPartitionCursorHandlerAction.get(id, partitionId, "500", null)
+
+      assertThat(response.statusCode).isEqualTo(200)
+      assertThat(cursorOf(id)).isEqualTo("500")
+    }
+  }
+
+  @Test
+  fun `refuses a partition belonging to a different backfill`() {
+    val otherId = createPausedBackfill("only")
+    val id = createPausedBackfill("only")
+
+    inScope {
+      val response = editPartitionCursorHandlerAction.get(id, onlyPartitionId(otherId), "", "500")
+
+      assertThat(response.statusCode).isEqualTo(200)
+      assertThat(cursorOf(otherId)).isNull()
+      assertThat(cursorOf(id)).isNull()
+    }
+  }
+
+  @Test
+  fun `leaves a cursor that is not utf8 untouched`() {
+    val id = createPausedBackfill("only")
+    val binaryCursor = ByteString.of(0xFF.toByte(), 0xFE.toByte())
+
+    inScope {
+      val partitionId = onlyPartitionId(id)
+      setCursorBytes(partitionId, binaryCursor)
+
+      val response = editPartitionCursorHandlerAction.get(id, partitionId, cursorOf(id), "500")
+
+      assertThat(response.statusCode).isEqualTo(200)
+      assertThat(cursorBytesOf(partitionId)).isEqualTo(binaryCursor)
+    }
+  }
+
+  private fun onlyPartitionId(id: Long) = getBackfillStatusAction.status(id).partitions.single().id
+
+  private fun cursorOf(id: Long) = getBackfillStatusAction.status(id).partitions.single().pkey_cursor
+
+  private fun cursorBytesOf(partitionId: Long) = transacter.transaction { session ->
+    queryFactory.newQuery<RunPartitionQuery>()
+      .partitionId(Id(partitionId))
+      .uniqueResult(session)!!
+      .pkey_cursor
+  }
+
+  private fun setCursorBytes(partitionId: Long, cursor: ByteString) {
+    transacter.transaction { session ->
+      queryFactory.newQuery<RunPartitionQuery>()
+        .partitionId(Id(partitionId))
+        .uniqueResult(session)!!
+        .pkey_cursor = cursor
+    }
+  }
+
+  private fun createPausedBackfill(partitionName: String): Long {
+    scope.fakeCaller(service = "deep-fryer") {
+      configureServiceAction.configureService(
+        ConfigureServiceRequest.Builder()
+          .backfills(
+            listOf(
+              ConfigureServiceRequest.BackfillData(
+                "ChickenSandwich", "Description", listOf(), null,
+                null, false, null, null,
+              ),
+            ),
+          )
+          .connector_type(Connectors.ENVOY)
+          .build(),
+      )
+    }
+
+    fakeBackfilaClientServiceClient.prepareBackfillResponses.add(
+      PrepareBackfillResponse.Builder()
+        .partitions(
+          listOf(
+            PrepareBackfillResponse.Partition.Builder()
+              .partition_name(partitionName)
+              .backfill_range(KeyRange("1".encodeUtf8(), "17701296".encodeUtf8()))
+              .build(),
+          ),
+        )
+        .build(),
+    )
+
+    return scope.fakeCaller(user = "molly") {
+      createBackfillAction.create(
+        "deep-fryer",
+        RESERVED_VARIANT,
+        CreateBackfillRequest.Builder()
+          .backfill_name("ChickenSandwich")
+          .build(),
+      ).backfill_run_id
+    }
+  }
+
+  private fun <T> inScope(function: () -> T): T = scope.create(
+    mapOf(
+      keyOf<MiskCaller>() to MiskCaller(user = "molly"),
+      HttpCall::class.toKey() to FakeHttpCall(
+        url = "http://backfila/api/backfill/1/partitions/1/cursor".toHttpUrl(),
+      ),
+    ),
+  ).inScope(function)
+
+  class TestModule : KAbstractModule() {
+    override fun configure() {
+      install(BackfilaTestingModule())
+      install(BaseDashboardModule(true))
+
+      install(
+        object : ActionScopedProviderModule() {
+          override fun configureProviders() {
+            bindSeedData(HttpCall::class)
+            bindSeedData(HttpRequest::class)
+            bindSeedData(HttpServletRequest::class)
+            bindSeedData(Action::class)
+            newMultibinder<MiskCallerAuthenticator>()
+          }
+        },
+      )
+    }
+  }
+}


### PR DESCRIPTION
### Background

The "Edit Cursor" link on the backfill page has never worked for a partition whose name needs
percent-encoding in a URL path. It has been broken this way since #448 introduced it.

`EditPartitionCursorAction` builds its own URL by substituting into a path template:

```kotlin
private const val PATH = "/backfills/{id}/{partitions}/{partitionName}/edit-cursor"
fun path(id: Long, partitionName: String) = PATH
  .replace("{id}", id.toString())
  .replace("{partitionName}", partitionName)
```

Two defects on those four lines, plus one in misk's binding, stack up:

1. `{partitions}` is never substituted, so every rendered href carries that literal text. misk treats
   the unbound template variable as a wildcard segment, so the route still resolves and the typo is
   invisible.
2. `partitionName` is interpolated raw. A name containing `#` truncates the URL at the fragment
   boundary, so the browser requests a shorter path that matches no route.
3. misk matches routes against `HttpUrl.encodedPath` (`PathPattern.matcher`) and binds `@PathParam`
   through an identity `StringConverter`, so a correctly percent-encoded name arrives at the action
   still encoded and `partitions.find { it.name == partitionName }` cannot match it. Encoding the
   link alone does not fix this; the action would also have to decode.

Reproduced on https://backfila.stage.sqprod.co/backfills/24852 (Block-internal staging), an `orders`
backfill whose partitions are named `region-shard-us-east#orders_local_ro_0`:

```
rendered href  /backfills/1/{partitions}/region-shard-us-east#orders_local_ro_0/edit-cursor
browser GET    /backfills/1/%7Bpartitions%7D/region-shard-us-east                      404
encoded GET    /backfills/1/%7Bpartitions%7D/region-shard-us-east%23orders_...          500
handler GET    /backfills/1/region-shard-us-east%23orders_.../edit-cursor               200
               "Edit partition failed. Partition not found: region-shard-us-east%23orders_local_ro_0"
```

Both failures are invisible to the operator. The link sits inside the partitions `<turbo-frame>`, and
misk returns `text/plain` for 404 and for "internal server error", which Turbo's `loadResponse` drops
without rendering. The button appears to do nothing at all.

Partition names come from client services verbatim and are never sanitized, and two bundled clients
already emit names that break the same link: the DynamoDB operators use `"$i of $partitionCount"`
(spaces) and the S3 operator uses object key suffixes (slashes).

### Change(s) Made

1. Address the partition by its numeric id instead of its name. `UiPartition.id` was already exposed
   and the write already keyed on it, so this removes the string from the URL entirely. No character
   class can break the link, and there is no decode for a future change to forget.
2. Give the two actions distinct, fully substituted paths: `/backfills/{id}/partitions/{partitionId}/edit-cursor`
   for the form, and `/api/backfill/{id}/partitions/{partitionId}/cursor` for the handler, matching
   where `BackfillShowButtonHandlerAction` puts its mutating endpoint. Simply deleting the stray
   `{partitions}` segment would have made the two `@Get` templates identical.
3. Retype `RunPartitionQuery.partitionId` from `Long` to `Id<DbRunPartition>`, matching every other
   constraint in that interface and preventing a backfill run id from being passed where a partition
   id is expected. This is a type-consistency change and not a correctness one: I checked, and the
   raw `Long` form binds and executes correctly. Happy to drop it if you would rather keep the diff
   and the ABI baseline narrower.
4. Read the form values with `@QueryParam` instead of unwrapping `ActionScoped<HttpCall>` by hand,
   and require a non-blank `new_cursor`. Previously a request without that parameter set the cursor
   to `NULL`, restarting the partition from the beginning of its range; `required = true` on the
   input was the only guard and it is client side only. This also replaces `isValidUtf8`, which
   compared `input.toByteArray(UTF_8)` to itself and could never return false.
5. Move the snapshot comparison into the write transaction and compare `ByteString` to `ByteString`.
   The snapshot was previously read in one transaction and applied in another, and it compared the
   lossy `pkey_cursor?.utf8()` rendering, so a cursor holding non UTF-8 bytes would pass validation
   and then be overwritten with the UTF-8 encoding of its own mangled rendering. That mattered more
   than it looks, because the form pre-fills `new_cursor` with the same lossy rendering, so
   submitting the form unedited silently rewrote the bytes.
6. Because of (5), a cursor whose bytes are not UTF-8 can no longer round-trip through the form at
   all. Rather than report that as a phantom concurrent modification, the handler now distinguishes
   the two refusals and says the cursor is not valid UTF-8, so nobody chases a writer that does not
   exist. `client-jooq` publishes a `forByteArray` key serializer, so this is a reachable state
   rather than a hypothetical one.

`Response` for a failed edit still carries status 200, and the mutation is still an `@Get`. Both are
pre-existing and shared with the sibling handler action, so they are left alone here.

### Scope & Impact

Backfila dashboard only. Two route paths change; neither previously resolved to a working page for
any name requiring encoding, and the form path never resolved at all because `path()` emitted a
literal `{partitions}`, so there are no working URLs to keep compatible.

`service/api/service.api` is regenerated per CONTRIBUTING.md. The changes are confined to the
`service` module, which is not a published client library, so no client ABI moves.

Behaviour change worth calling out: clearing a cursor back to `NULL` through this endpoint is no
longer possible. It was only reachable by hand editing the URL, and it deserves its own explicit
affordance if anyone wants it.

### Related Documents/PRs

1. #448, which introduced the feature. Its only test was removed during review before merge, so
   there has been no coverage of either action.

### Testing Performed

New `service/src/test/kotlin/app/cash/backfila/actions/EditPartitionCursorActionTest.kt`, eight tests:

1. `paths never interpolate the partition name` pins both generated paths against literals. Against
   the old code it neither compiles (the old `path()` took the name as a `String`) nor passes (it
   returned a literal `{partitions}` segment). This is the assertion that pins the bug class.
2. `form page renders for a partition whose name is not url safe` covers the form action, including
   its `BadRequestException` on an unknown partition id. Note `buildHtmlResponseBody` defers to
   `writeTo`, so this asserts the action completes rather than asserting on rendered markup.
3. `edits a partition whose name is not url safe` and
   `edits a partition using the matching non null snapshot the form submits` cover both branches of
   the rewritten comparison. Both pass `cursor_snapshot` as the form actually sends it, empty for a
   never-started partition rather than absent.
4. `rejects a stale snapshot`, `a missing new cursor does not clear the cursor`, and
   `refuses a partition belonging to a different backfill` pin the guards, the last one covering the
   new `backfillRunId` scoping on the write query.
5. `leaves a cursor that is not utf8 untouched` writes raw `FF FE` to `pkey_cursor` and asserts the
   bytes survive the attempted edit. This fails on master, which overwrote them with `EF BF BD`.

These call the actions directly rather than over HTTP, so they cover the write path rather than URL parsing;

