### PR TITLE
Stop cloning one partition's position onto every partition

### DIFF
--- a/service/src/main/kotlin/app/cash/backfila/ui/actions/BackfillCreateHandlerAction.kt
+++ b/service/src/main/kotlin/app/cash/backfila/ui/actions/BackfillCreateHandlerAction.kt
@@ -2,6 +2,7 @@ package app.cash.backfila.ui.actions
 
 import app.cash.backfila.dashboard.CreateBackfillAction
 import app.cash.backfila.dashboard.GetBackfillStatusAction
+import app.cash.backfila.dashboard.UiPartition
 import app.cash.backfila.protos.service.CreateBackfillRequest
 import app.cash.backfila.ui.components.AlertError
 import app.cash.backfila.ui.components.DashboardPageLayout
@@ -58,24 +59,18 @@ class BackfillCreateHandlerAction @Inject constructor(
           // Get the last processed position from the original backfill
           val backfillId = formFields[BackfillCreateField.BACKFILL_ID_TO_CLONE.fieldId]?.toLongOrNull()
           backfillId?.let { id ->
-            val status = getBackfillStatusAction.status(id)
-            status.partitions.firstOrNull()?.let { partition ->
-              // Use cursor if available, otherwise use start
-              val startValue = partition.pkey_cursor ?: partition.pkey_start
-              startValue?.let { createRequestBuilder.pkey_range_start(it.encodeUtf8()) }
-              partition.pkey_end?.let { createRequestBuilder.pkey_range_end(it.encodeUtf8()) }
-            }
+            val range = continueRange(getBackfillStatusAction.status(id).partitions)
+            range.start?.let { createRequestBuilder.pkey_range_start(it.encodeUtf8()) }
+            range.end?.let { createRequestBuilder.pkey_range_end(it.encodeUtf8()) }
           }
         }
         RangeOption.RESTART.value -> {
           // Use the original range but start from beginning
           val backfillId = formFields[BackfillCreateField.BACKFILL_ID_TO_CLONE.fieldId]?.toLongOrNull()
           backfillId?.let { id ->
-            val status = getBackfillStatusAction.status(id)
-            status.partitions.firstOrNull()?.let { partition ->
-              partition.pkey_start?.let { createRequestBuilder.pkey_range_start(it.encodeUtf8()) }
-              partition.pkey_end?.let { createRequestBuilder.pkey_range_end(it.encodeUtf8()) }
-            }
+            val range = restartRange(getBackfillStatusAction.status(id).partitions)
+            range.start?.let { createRequestBuilder.pkey_range_start(it.encodeUtf8()) }
+            range.end?.let { createRequestBuilder.pkey_range_end(it.encodeUtf8()) }
           }
         }
         else -> {
@@ -125,7 +120,46 @@ class BackfillCreateHandlerAction @Inject constructor(
     )
   }
 
+  /** The range a clone should start from, in the same string form the create form submits. */
+  internal data class CloneRange(val start: String?, val end: String?)
+
   companion object {
+    /**
+     * A clone carries one range for every partition of the new backfill, so a position that differs
+     * between the source partitions cannot be carried over at all.
+     *
+     * Each partition holds its own cursor, so continuing is only expressible when the source has a
+     * single partition. Taking any one partition's cursor for all of them would rewind the
+     * partitions that ran ahead of it, and skip every row between the cursor and the true position
+     * of the partitions that lag behind it.
+     */
+    internal fun continueRange(partitions: List<UiPartition>): CloneRange {
+      require(partitions.size == 1) {
+        "Cannot continue a backfill that has ${partitions.size} partitions. Each partition has its" +
+          " own cursor, and a clone applies one range to every partition, so continuing would" +
+          " rewind the partitions that ran ahead and skip rows in the partitions that lag behind." +
+          " Clone it with a new range instead."
+      }
+      val partition = partitions.single()
+      return CloneRange(partition.pkey_cursor ?: partition.pkey_start, partition.pkey_end)
+    }
+
+    /**
+     * Restarting can carry the range over when every source partition shares it, which is the case
+     * when the original run was given an explicit range. When the partitions computed their own
+     * ranges those differ, and no single range reproduces them, so the range is left unset and each
+     * partition of the clone computes its own again.
+     */
+    internal fun restartRange(partitions: List<UiPartition>): CloneRange {
+      val starts = partitions.mapTo(mutableSetOf()) { it.pkey_start }
+      val ends = partitions.mapTo(mutableSetOf()) { it.pkey_end }
+      return if (starts.size == 1 && ends.size == 1) {
+        CloneRange(starts.single(), ends.single())
+      } else {
+        CloneRange(null, null)
+      }
+    }
+
     private val logger = getLogger<BackfillCreateHandlerAction>()
 
     const val PATH = "/api/backfill/create"

--- a/service/src/test/kotlin/app/cash/backfila/actions/BackfillCloneRangeTest.kt
+++ b/service/src/test/kotlin/app/cash/backfila/actions/BackfillCloneRangeTest.kt
@@ -1,0 +1,99 @@
+package app.cash.backfila.actions
+
+import app.cash.backfila.dashboard.UiPartition
+import app.cash.backfila.service.persistence.BackfillState
+import app.cash.backfila.ui.actions.BackfillCreateHandlerAction.Companion.continueRange
+import app.cash.backfila.ui.actions.BackfillCreateHandlerAction.Companion.restartRange
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * A clone carries one range for every partition, so these cover which source positions can be
+ * expressed as a single range and which cannot.
+ */
+class BackfillCloneRangeTest {
+  @Test
+  fun `continuing a single partition uses its cursor`() {
+    val range = continueRange(listOf(partition("only", cursor = "500", start = "1", end = "9000")))
+
+    assertThat(range.start).isEqualTo("500")
+    assertThat(range.end).isEqualTo("9000")
+  }
+
+  @Test
+  fun `continuing a single partition that never started uses its range start`() {
+    val range = continueRange(listOf(partition("only", cursor = null, start = "1", end = "9000")))
+
+    assertThat(range.start).isEqualTo("1")
+    assertThat(range.end).isEqualTo("9000")
+  }
+
+  @Test
+  fun `continuing refuses more than one partition`() {
+    val partitions = listOf(
+      partition("shard-1", cursor = "500", start = "1", end = "9000"),
+      partition("shard-2", cursor = "7000", start = "1", end = "9000"),
+    )
+
+    assertThatThrownBy { continueRange(partitions) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("Cannot continue a backfill that has 2 partitions")
+  }
+
+  @Test
+  fun `restarting carries a range every partition shares`() {
+    val partitions = listOf(
+      partition("shard-1", cursor = "500", start = "1", end = "9000"),
+      partition("shard-2", cursor = "7000", start = "1", end = "9000"),
+    )
+
+    val range = restartRange(partitions)
+
+    assertThat(range.start).isEqualTo("1")
+    assertThat(range.end).isEqualTo("9000")
+  }
+
+  @Test
+  fun `restarting drops a range that differs between partitions`() {
+    val partitions = listOf(
+      partition("shard-1", cursor = "500", start = "1", end = "9000"),
+      partition("shard-2", cursor = "7000", start = "1", end = "17701296"),
+    )
+
+    val range = restartRange(partitions)
+
+    assertThat(range.start).isNull()
+    assertThat(range.end).isNull()
+  }
+
+  @Test
+  fun `restarting a single partition carries its range`() {
+    val range = restartRange(listOf(partition("only", cursor = "500", start = "1", end = "9000")))
+
+    assertThat(range.start).isEqualTo("1")
+    assertThat(range.end).isEqualTo("9000")
+  }
+
+  private fun partition(
+    name: String,
+    cursor: String?,
+    start: String?,
+    end: String?,
+  ) = UiPartition(
+    id = 1L,
+    name = name,
+    state = BackfillState.PAUSED,
+    pkey_cursor = cursor,
+    pkey_start = start,
+    pkey_end = end,
+    precomputing_done = false,
+    precomputing_pkey_cursor = null,
+    computed_scanned_record_count = 0,
+    computed_matching_record_count = 0,
+    backfilled_scanned_record_count = 0,
+    backfilled_matching_record_count = 0,
+    scanned_records_per_minute = null,
+    matching_records_per_minute = null,
+  )
+}


### PR DESCRIPTION
## Problem

`BackfillCreateHandlerAction` took `status.partitions.firstOrNull()` for both the Continue and the Restart range options:

```kotlin
status.partitions.firstOrNull()?.let { partition ->
  val startValue = partition.pkey_cursor ?: partition.pkey_start
  startValue?.let { createRequestBuilder.pkey_range_start(it.encodeUtf8()) }
  partition.pkey_end?.let { createRequestBuilder.pkey_range_end(it.encodeUtf8()) }
}
```

`CreateBackfillRequest` carries a **single** range, and `JooqBackfillOperator.computeOverallRange` applies it to every partition:

```kotlin
val rangeEnd = if (request.range == null || request.range.end == null) {
  backfill.toByteString(backfill.getUnfilteredBoundaryKeyValue(partitionName) { it.desc() } ...)
} else {
  request.range.end
}
```

On a backfill with one partition this is correct. On a partitioned backfill it silently moves **every** partition to partition zero's position:

- Partitions that ran ahead of partition zero are rewound and reprocess rows.
- Partitions that lag behind it **skip every row** between partition zero's cursor and their own true position.

Each partition has an independent key sequence, so partition zero's cursor carries no information about where the others are. The skip is silent: the clone reports success and finishes early.

## Change

**Continue** is not expressible as a single range when the source has more than one partition, so it is now rejected with a message that says why. The action already wraps its body in a `try`/`catch` that renders the failure, so the operator sees the reason rather than a corrupted clone.

**Restart** carries the range over only when every source partition shares it, which is the case when the original run was given an explicit range on the creation screen. When the partitions computed their own ranges no single range reproduces them, so the range is left unset and each partition of the clone computes its own again. That is what the original run did, so restart keeps working on partitioned backfills.

Both decisions are extracted into pure functions of the source partitions, `continueRange` and `restartRange`.

## Alternatives considered

Aggregating across partitions, for example taking the minimum cursor as the start, would keep Continue working for partitioned backfills. It is not implementable here: a cursor is an opaque `ByteString` whose encoding is chosen by the client's `ByteStringSerializer`, so the service cannot order two cursors. `forLong` encodes a long as its decimal string, where a lexicographic minimum of `"9"` and `"10"` is `"10"`.

Carrying a cursor per partition into the created partitions would make Continue work properly, but it needs a per partition field on `CreateBackfillRequest` and matching plumbing in `BackfillCreator`. That is worth doing separately. This change stops the data loss first.

## Tests

`BackfillCloneRangeTest` covers both functions without a database:

- continuing a single partition uses its cursor
- continuing a single partition that never started uses its range start
- continuing refuses more than one partition
- restarting carries a range every partition shares
- restarting drops a range that differs between partitions
- restarting a single partition carries its range

## Verification

`:service:test --tests "*BackfillCloneRangeTest*"` passes, 6 of 6. `:service:spotlessCheck` passes.

This environment has no provisioned MySQL, so I could not run the DB backed tests in `:service`. The new tests are deliberately free of the database for that reason. Please rely on CI for the rest.
